### PR TITLE
Remove users

### DIFF
--- a/docs/learn/high-level-overview.mdx
+++ b/docs/learn/high-level-overview.mdx
@@ -4,7 +4,7 @@ title: High level overview
 ---
 
 ## Rust language
-Contracts are small programs written in the [Rust programming language](https://www.rust-lang.org). In order to write contracts, users will need to [install a Rust toolchain](https://www.rust-lang.org/tools/install), configure their [editor to support Rust programs](https://www.rust-lang.org/tools), and [learn at least some basic Rust concepts](https://www.rust-lang.org/learn).
+Contracts are small programs written in the [Rust programming language](https://www.rust-lang.org). In order to write contracts, [install a Rust toolchain](https://www.rust-lang.org/tools/install), configure your [editor to support Rust programs](https://www.rust-lang.org/tools), and [learn at least some basic Rust concepts](https://www.rust-lang.org/learn).
 
 Contracts can be compiled to native code for local (off-chain) testing, but must be compiled as WebAssembly ("WASM") for deployment. The on-chain host environment only allows uploading WASM contracts, and runs them within a WASM "sandbox" virtual machine ("VM").
 


### PR DESCRIPTION
### What
Remove "users".

### Why
It is ambiguous to who this refers. We should avoid the term user distances us from the target audience, and refers to the reader in the third person, when the reader is likely the user.