### PR TITLE
Do not wrap inline code blocks

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -91,3 +91,7 @@
 //   height: 100%;
 //   padding: 2rem 0;
 // }
+
+code {
+  white-space: nowrap;
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -92,6 +92,6 @@
 //   padding: 2rem 0;
 // }
 
-code {
+p > code {
   white-space: nowrap;
 }


### PR DESCRIPTION
### What
Change the css for code blocks so they do not wrap on lines.

### Why
Inline code blocks look odd when wrapped. Typically they are an identifier, or something that should be considered like a single word.