### PR TITLE
Fix headings

### DIFF
--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -4,9 +4,13 @@ title: Cross Contract Calls
 ---
 
 The [cross contract call example] demonstrates how to call a contract from
-another contract. In this example both contracts will be compiled into a single
+another contract.
+
+:::info
+In this example both contracts will be compiled into a single
 contract binary, but the same principles apply for contracts compiled
 separately.
+:::
 
 [cross contract call example]: https://github.com/stellar/soroban-examples/tree/main/cross_contract_calls
 
@@ -159,7 +163,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Host environment that the contract will run it.
+Soroban environment that the contract will run in.
 
 ```rust
 let env = Env::default();
@@ -205,7 +209,7 @@ The test asserts that the result that is returned is as we expect.
 assert_eq!(sum, 12);
 ```
 
-## Build WASM
+## Build the Contract
 
 To build the contract into a `.wasm` file, use the `cargo build` command.
 
@@ -219,12 +223,12 @@ A `.wasm` file should be outputted in the `../target` directory:
 ../target/wasm32-unknown-unknown/release/soroban_cross_contract_calls_contract.wasm
 ```
 
-## Run the WASM
+## Run the Contract
 
-If you have [`soroban-cli`] installed, you can invoke contract functions in the
-WASM using it. Both contracts live in the same compiled contract and so we'll deploy it once
-
-Deploy the contract twice. The first we'll use as the callee, and the second as the caller.
+If you have [`soroban-cli`] installed, you can invoke contract functions. Both
+contracts live in the same compiled contract and so we'll deploy the contract
+twice. The first deployment we'll use as the callee, and the second as the
+caller.
 
 ```sh
 soroban-cli deploy \

--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -14,7 +14,7 @@ separately.
 
 [cross contract call example]: https://github.com/stellar/soroban-examples/tree/main/cross_contract_calls
 
-## Run the example
+## Run the Example
 
 First go through the [Setup] process to get your development environment
 configured, then clone the examples repository:

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -9,7 +9,7 @@ invocations.
 
 [custom types example]: https://github.com/stellar/soroban-examples/tree/main/custom_types
 
-## Run the example
+## Run the Example
 
 First go through the [Setup] process to get your development environment
 configured, then clone the examples repository:

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -169,7 +169,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Host environment that the contract will run it.
+Soroban environment that the contract will run in.
 
 ```rust
 let env = Env::default();
@@ -221,9 +221,9 @@ assert_eq!(
 );
 ```
 
-## Build WASM
+## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo build` command.
+To build the contract, use the `cargo build` command.
 
 ```sh
 cargo build --target wasm32-unknown-unknown --release
@@ -235,7 +235,7 @@ A `.wasm` file should be outputted in the `../target` directory:
 ../target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm
 ```
 
-## Run the WASM
+## Run the Contract
 
 The `soroban-cli` is in early development and does not yet accept user-defined
 types as arguments at the command line. Follow the GitHub repository to find out

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -145,9 +145,9 @@ assert_eq!(
 );
 ```
 
-## Build WASM
+## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo build` command.
+To build the contract, use the `cargo build` command.
 
 ```sh
 cargo build --target wasm32-unknown-unknown --release
@@ -159,10 +159,10 @@ A `.wasm` file should be outputted in the `../target` directory:
 ../target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm
 ```
 
-## Run the WASM
+## Run the Contract
 
 If you have [`soroban-cli`] installed, you can invoke contract functions in the
-WASM using it.
+using it.
 
 ```sh
 soroban-cli invoke \

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -115,7 +115,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Soroban environment that the contract will run it.
+Soroban environment that the contract will run in.
 
 ```rust
 let env = Env::default();

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -74,17 +74,17 @@ pub struct HelloContract;
 
 Contract functions look much like regular Rust functions. They mave have any
 number of arguments, but arguments must support being transmitted to and from
-the Host environment that the contract runs in. The Soroban SDK provides some
-types like `Symbol`, `Vec`, `Map`, `Binary`, `FixedBinary`, etc that can be
-used. Primitive values like `u64`, `i64`, `u32`, `i32`, and `bool` can also be
-used. Floats are not supported.
+the Soroban environment that the contract runs in. The Soroban SDK provides some
+types like `Vec`, `Map`, `BigInt`, `Symbol`, `Binary`, `FixedBinary`, etc that
+can be used. Primitive values like `u64`, `i64`, `u32`, `i32`, and `bool` can
+also be used. Floats are not supported.
 
 Contract inputs must not be references.
 
 If the first argument of a contract function is of the `soroban_sdk::Env` type,
-an `Env` will be provided that provides access to Host functionality. Most
-functionality within the SDK requires an Env, so it is recommended to have it in
-the argument list for most functions.
+an `Env` will be provided that provides access to additional functionality. Most
+functionality within the SDK requires an `Env`, so it is recommended to have it
+in the argument list for most functions.
 
 ```rust
 #[contractimpl]
@@ -115,7 +115,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Host environment that the contract will run it.
+Soroban environment that the contract will run it.
 
 ```rust
 let env = Env::default();

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -8,7 +8,7 @@ single function that takes one input and returns it as an output.
 
 [hello world example]: https://github.com/stellar/soroban-examples/tree/main/hello_world
 
-## Run the example
+## Run the Example
 
 First go through the [Setup] process to get your development environment
 configured, then clone the examples repository:

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -132,7 +132,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Soroban environment that the contract will run it.
+Soroban environment that the contract will run in.
 
 ```rust
 let env = Env::default();

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -58,16 +58,17 @@ Ref: https://github.com/stellar/soroban-examples/tree/main/increment
 
 ## How it Works
 
-Open the `hello_world/src/lib.rs` file to follow along.
+Open the `increment/src/lib.rs` file to follow along.
 
 ### Contract Data Keys
 
 Contract data that is stored is stored associated with a key. The key is the
 value that can be used at a later time to lookup the value.
 
-`Symbol`s are a space and execution efficient value to use as static keys. When
-produced in a `const` variable they are computed at compile time and stored in
-code as a 64-bit value. Their maximum character length is 10.
+`Symbol`s are a space and execution efficient value to use as static keys or
+names of things. They can also be used as short strings. When produced in a
+`const` variable they are computed at compile time and stored in code as a
+64-bit value. Their maximum character length is 10.
 
 ```rust
 const COUNTER: Symbol = Symbol::from_str("COUNTER");
@@ -78,8 +79,8 @@ const COUNTER: Symbol = Symbol::from_str("COUNTER");
 The `Env` `contract_data()` function is used to retrieve access and update a
 counter. The executing contract is the only contract that can query or modify
 contract data that it has stored. The data stored is viewable on ledger anywhere
-the ledger is viewable, but contracts executing within the Host environment are
-restricted to their own data.
+the ledger is viewable, but contracts executing within the Soroban environment
+are restricted to their own data.
 
 The `get()` function gets the current value associated with the counter key.
 
@@ -94,12 +95,12 @@ let mut count: u32 = env
 If no value is currently stored, the value given to `unwrap_or(...)` is returned
 instead.
 
-Values stored as contract data and retrieved are transmitted from the host and
-expanded into the type specified. In this case a `u32`. If the value can be
-expanded the type returned will be an `Ok(u32)`, otherwise the type returned
-will be an `Err(_)`. The final `unwrap()` in the above code snippet is assuming
-the value will always be a u32. If a developer caused it to be some other type a
-panic would occur at the unwrap.
+Values stored as contract data and retrieved are transmitted from the
+environment and expanded into the type specified. In this case a `u32`. If the
+value can be expanded the type returned will be an `Ok(u32)`, otherwise the type
+returned will be an `Err(_)`. The final `unwrap()` in the above code snippet is
+assuming the value will always be a `u32`. If a developer caused it to be some
+other type a panic would occur at the unwrap.
 
 The `set()` function stores the new count value against the key, replacing the
 existing value.
@@ -131,7 +132,7 @@ fn test() {
 ```
 
 In any test the first thing that is always required is an `Env`, which is the
-Host environment that the contract will run it.
+Soroban environment that the contract will run it.
 
 ```rust
 let env = Env::default();
@@ -158,9 +159,9 @@ The values returned by functions can be asserted on:
 assert_eq!(count, 1);
 ```
 
-## Build WASM
+## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo build` command.
+To build the contract, use the `cargo build` command.
 
 ```sh
 cargo build --target wasm32-unknown-unknown --release
@@ -172,7 +173,7 @@ A `.wasm` file should be outputted in the `../target` directory:
 ../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
 ```
 
-## Run the WASM
+## Run the Contract
 
 If you have [`soroban-cli`] installed, you can invoke contract functions in the
 WASM using it.

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -8,7 +8,7 @@ single function that increments an internal counter and returns the value.
 
 [increment example]: https://github.com/stellar/soroban-examples/tree/main/increment
 
-## Run the example
+## Run the Example
 
 First go through the [Setup] process to get your development environment
 configured, then clone the examples repository:

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -128,7 +128,7 @@ test test::test ... ok
 
 Try changing the values in the test to see how it works.
 
-## Build WASM
+## Build the Contract
 
 To build the contract into a `.wasm` file, use the `cargo build` command.
 
@@ -142,10 +142,10 @@ A `.wasm` file should be outputted in the `target` directory:
 target/wasm32-unknown-unknown/release/first-project.wasm
 ```
 
-## Run the WASM
+## Run the Contract
 
 If you have [`soroban-cli`] installed, you can invoke contract functions in the
-WASM using it.
+contract.
 
 ```sh
 soroban-cli invoke \
@@ -155,7 +155,7 @@ soroban-cli invoke \
     --arg friend
 ```
 
-The following output should occur using the code above.
+You should see the following output:
 
 ```json
 ["Hello","friend"]

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -5,7 +5,7 @@ title: Setup
 
 Soroban contracts are small programs written in the [Rust] programming language.
 
-To build and develop contracts you need only a couple pre-requisites:
+To build and develop contracts you need only a couple prerequisites:
 
 - A [Rust] toolchain
 - An editor that supports Rust

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -5,9 +5,7 @@ title: Setup
 
 Soroban contracts are small programs written in the [Rust] programming language.
 
-To build and develop contracts you need only a couple pre-requisites: To setup
-your development environment to develop contracts, you need only a couple
-pre-requisites:
+To build and develop contracts you need only a couple pre-requisites:
 
 - A [Rust] toolchain
 - An editor that supports Rust
@@ -40,8 +38,8 @@ https://www.rust-lang.org/tools
 
 ## Install the Soroban CLI
 
-The Soroban CLI can execute WASM contracts in the same environment the contract
-will execute on network, however in a local sandbox.
+The Soroban CLI can execute Soroban contracts in the same environment the
+contract will execute on network, however in a local sandbox.
 
 Install the Soroban CLI using `cargo install`.
 

--- a/docs/tutorials/build-and-run.mdx
+++ b/docs/tutorials/build-and-run.mdx
@@ -5,13 +5,15 @@ title: Build and Run
 
 ## Build a Contract
 
-To build a Soroban contract into a `.wasm` file, use the `cargo build` command.
+To build a Soroban contract to deploy or run with the [`soroban-cli`], use the
+`cargo build` command.
 
 ```sh
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `target` directory:
+A `.wasm` file will be outputted in the `target` directory. The `.wasm` file is
+the built contract.
 
 ```
 target/wasm32-unknown-unknown/release/[project-name].wasm
@@ -19,12 +21,12 @@ target/wasm32-unknown-unknown/release/[project-name].wasm
 
 ## Run a Contract
 
-If you have [`soroban-cli`] installed, you can invoke contract functions in a
-WASM file.
+If you have the [`soroban-cli`] installed, you can invoke contract functions
+that have been built.
 
 Using the code we wrote in [Write a Contract] and the resulting `.wasm` file
 we built in [Build and Run] run the following command to invoke the `hello`
-function with a single argument `"friend"`.
+function with a single argument `friend`.
 
 ```sh
 soroban-cli invoke \

--- a/docs/tutorials/build-optimized.mdx
+++ b/docs/tutorials/build-optimized.mdx
@@ -21,7 +21,7 @@ It is highly recommended to use the release profile outlined in [Configure the
 Release Profile], otherwise the contract will be too large to deploy or run.
 :::
 
-[Create a Project]: create-a-project#configure-the-release-profile
+[Configure the Release Profile]: create-a-project#configure-the-release-profile
 
 ## Install Rust `nightly`
 
@@ -29,6 +29,7 @@ To install the nightly Rust toolchain use `rustup`.
 
 ```sh
 rustup install nightly
+rustup target add --toolchain nightly wasm32-unknown-unknown
 ```
 
 ## Install `wasm-opt`

--- a/docs/tutorials/testing.mdx
+++ b/docs/tutorials/testing.mdx
@@ -3,13 +3,19 @@ sidebar_position: 5
 title: Testing
 ---
 
-Writing tests for Soroban contracts involves writing Rust code using the Rust
-test facilities and toolchain that you'd use for testing any Rust code.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Writing tests for Soroban contracts involves writing Rust code using the test
+facilities and toolchain that you'd use for testing any Rust code.
 
 Given a simple contract like the contract demonstrated in [Write a
-Contract](write-a-contract.mdx).
+Contract](write-a-contract.mdx), a simple test will look like this.
 
-```rust title="src/lib.rs"
+<Tabs>
+<TabItem value="lib.rs" label="src/lib.rs">
+
+```rust
 #![no_std]
 use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
 
@@ -24,9 +30,10 @@ impl Contract {
 }
 ```
 
-A simple test will look like this.
+</TabItem>
+<TabItem value="test.rs" label="src/test.rs" default>
 
-```rust title="src/test.rs"
+```rust
 #![cfg(test)]
 
 use super::{Contract, hello};
@@ -46,8 +53,11 @@ fn test() {
 }
 ```
 
+</TabItem>
+</Tabs>
+
 In any test the first thing that is always required is an `Env`, which is the
-Host environment that the contract will run it.
+Soroban environment that the contract will run inside of.
 
 ```rust
 let env = Env::default();

--- a/docs/tutorials/write-a-contract.mdx
+++ b/docs/tutorials/write-a-contract.mdx
@@ -25,9 +25,9 @@ how to setup a project.
 
 Many of the types available in typical Rust programs, such as `std::vec::Vec`,
 are not available, as there is no allocator and no heap memory in Soroban
-contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, and
-`BigInt`, `Binary`, `FixedBinary`, that all utilize the Host environment's memory
-and native capabilities.
+contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`,
+`BigInt`, `Binary`, `FixedBinary`, that all utilize the Soroban environment's
+memory and native capabilities.
 
 ```rust
 pub struct Contract;
@@ -40,10 +40,11 @@ impl Contract {
 }
 ```
 
-Contract functions live inside a `impl` for a struct. The `impl` block is
-annotated with `#[contractimpl]`, and the functions that are intended to be
-called are assigned `pub` visibility and have an `Env` argument as their first
-argument.
+Contract functions live inside an `impl` for a struct. The `impl` block is
+annotated with `#[contractimpl]`. Functions that are intended to be called
+externally are should be marked with `pub` visibility. The first argument can be
+an `Env` argument to get a copy of the Soroban environment, which is necessary
+for most things.
 
 Implementations annotated can be configured to export the contract functions
 only if a feature is enabled, with `export_if = "[feature-name]"`.


### PR DESCRIPTION
### What
Change the case of some headings to be title case.

### Why
It seems some of the headings I wrote were sentence case, which is inconsistent with most other headings in these docs which are title case.