### PR TITLE
Add warning for hyphenated project names

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -142,7 +142,7 @@ A `.wasm` file should be outputted in the `target` directory:
 target/wasm32-unknown-unknown/release/first_project.wasm
 ```
 
-:::caution
+:::info
 Hyphens get replaced by underscores, so `first-project` is outputted as `first_project.wasm`.
 :::
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -143,7 +143,7 @@ target/wasm32-unknown-unknown/release/first_project.wasm
 ```
 
 :::info
-Hyphens get replaced by underscores, so `first-project` is outputted as `first_project.wasm`.
+Hyphens in Rust crate names are replaced by underscores in code and generated file names, so `first-project` is outputted as `first_project.wasm`.
 :::
 
 ## Run the Contract

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -139,8 +139,12 @@ cargo build --target wasm32-unknown-unknown --release
 A `.wasm` file should be outputted in the `target` directory:
 
 ```
-target/wasm32-unknown-unknown/release/first-project.wasm
+target/wasm32-unknown-unknown/release/first_project.wasm
 ```
+
+:::caution
+Hyphens get replaced by underscores, so `first-project` is outputted as `first_project.wasm`.
+:::
 
 ## Run the Contract
 
@@ -149,7 +153,7 @@ contract.
 
 ```sh
 soroban-cli invoke \
-    --wasm target/wasm32-unknown-unknown/release/first-project.wasm \
+    --wasm target/wasm32-unknown-unknown/release/first_project.wasm \
     --id 1 \
     --fn hello \
     --arg friend

--- a/docs/tutorials/build-and-run.mdx
+++ b/docs/tutorials/build-and-run.mdx
@@ -16,7 +16,7 @@ A `.wasm` file will be outputted in the `target` directory. The `.wasm` file is
 the built contract.
 
 ```
-target/wasm32-unknown-unknown/release/[project-name].wasm
+target/wasm32-unknown-unknown/release/[project_name].wasm
 ```
 
 ## Run a Contract
@@ -30,7 +30,7 @@ function with a single argument `friend`.
 
 ```sh
 soroban-cli invoke \
-    --wasm target/wasm32-unknown-unknown/release/first-project.wasm \
+    --wasm target/wasm32-unknown-unknown/release/first_project.wasm \
     --id 1 \
     --fn hello \
     --arg friend

--- a/docs/tutorials/build-optimized.mdx
+++ b/docs/tutorials/build-optimized.mdx
@@ -82,6 +82,6 @@ Then additionally use `wasm-opt` to further minimize the size of the `.wasm`.
 
 ```sh
 wasm-opt -Oz \
-    target/wasm32-unknown-unknown/release/first-project.wasm \
+    target/wasm32-unknown-unknown/release/first_project.wasm \
     -o target/wasm32-unknown-unknown/release/first-project-optimized.wasm
 ```


### PR DESCRIPTION
Hyphenated project names are outputted with underscores instead.