### PR TITLE
Correction of references in text - add_width

### DIFF
--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -186,7 +186,7 @@ All public functions within an `impl` block that is annotated with the
 `#[contractimpl]` attribute have an `invoke` function generated, that can be
 used to invoke the contract function within the environment.
 
-The test invokes contract `b`'s `add_width` function with two values to add, and
+The test invokes contract `b`'s `add_with` function with two values to add, and
 the contract ID of contract `a`.
 
 ```rust
@@ -260,7 +260,7 @@ The following output should occur using the code above.
 12
 ```
 
-Contract `1`'s `add_width` function invoked contract `0`'s `add` function to do
+Contract `1`'s `add_with` function invoked contract `0`'s `add` function to do
 the addition.
 
 :::info


### PR DESCRIPTION
While reading the example I came across a repeating typo of add_width that should be add_with.

Soroban looks interesting. Looking forward to see where it goes.