### PR TITLE
Add missing `Clone` trait to code

### DIFF
--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -38,12 +38,14 @@ test test::test ... ok
 
 ```rust title="custom_types/src/lib.rs"
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Name {
     None,
     FirstLast(FirstLast),
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirstLast {
     pub first: Symbol,
     pub last: Symbol,
@@ -87,6 +89,7 @@ Field names must be no more than 10 characters.
 
 ```rust
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirstLast {
     pub first: Symbol,
     pub last: Symbol,
@@ -104,6 +107,7 @@ below, are supported.
 
 ```rust
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Name {
     None,
     FirstLast(FirstLast),


### PR DESCRIPTION
Clone trait is required, without it the code cannot be compiled.

```
error[E0277]: the trait bound `RawVal: From<&Name>` is not satisfied
  --> src/lib.rs:23:1
   |
23 | #[contractimpl(export_if = "export")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&Name>` is not implemented for `RawVal`
   |
   = help: the following other types implement trait `From<T>`:
             <RawVal as From<&()>>
             <RawVal as From<&ScStatus>>
             <RawVal as From<&i32>>
             <RawVal as From<&u32>>
             <RawVal as From<()>>
             <RawVal as From<Account>>
             <RawVal as From<FixedBinary<N>>>
             <RawVal as From<ScStatus>>
           and 19 others
   = note: required because of the requirements on the impl of `Into<RawVal>` for `&Name`
   = note: required because of the requirements on the impl of `IntoVal<Env, RawVal>` for `&Name`
   = note: this error originates in the attribute macro `contractimpl` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `custom-type` due to previous error
```

I think this might be confusing for beginers, but if this is intentional, please feel free to close this PR