### PR TITLE
Update code samples in quickstart

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -93,16 +93,16 @@ impl Contract {
 #[cfg(test)]
 mod test {
     use super::{Contract, ContractClient};
-    use soroban_sdk::{symbol, vec, BytesN, Env, Symbol};
+    use soroban_sdk::{symbol, vec, BytesN, Env};
 
     #[test]
     fn test() {
         let env = Env::default();
-        let contract_id = BytesN::from_array(&env, [0; 32]);
+        let contract_id = BytesN::from_array(&env, &[0; 32]);
         env.register_contract(&contract_id, Contract);
         let client = ContractClient::new(&env, &contract_id);
 
-        let words = client.hello(symbol!("Dev"));
+        let words = client.hello(&symbol!("Dev"));
         assert_eq!(
             words,
             vec![&env, symbol!("Hello"), symbol!("Dev"),]

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -59,11 +59,16 @@ lto = true
 ```
 
 The `features` list includes a `testutils` feature, which will cause additional
-test utilities to be generated for calling the contract in tests. The test
-utilities are automatically available inside Rust unit tests inside the same
-crate as your contract. If you write Rust integration tests, or write tests from
-another crate, you'll need to use the `testutils` feature to be able to use
-those test utilities.
+test utilities to be generated for calling the contract in tests.
+
+:::info
+The `testutils` test utilities are automatically enabled inside [Rust unit
+tests] inside the same crate as your contract. If you write [Rust integration
+tests], or write tests from another crate, you'll need to add `#[cfg(feature =
+"testutils")]` to those tests and enable the `testutils` feature when running
+your tests with `cargo test --features testutils` to be able to use those test
+utilities.
+:::
 
 The config for the `release` profile configures the Rust toolchain to produce
 smaller contracts.
@@ -159,3 +164,6 @@ You should see the following output:
 ```
 
 [`soroban-cli`]: setup#install-the-soroban-cli
+
+[Rust unit tests]: https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html
+[Rust integration tests]: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -39,15 +39,13 @@ The `soroban-sdk` is in early development. Report issues
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
 soroban-sdk = "0.0.4"
 
 [dev_dependencies]
-first-project = { path = ".", features = ["testutils"] }
+soroban-sdk = { version = "0.0.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"
@@ -60,17 +58,12 @@ codegen-units = 1
 lto = true
 ```
 
-The `features` list and `dev_dependencies` configure three variations that the
-contract can be built with:
-- By `default`, with `export` enabled, contract functions will be exported and
-available to be invoked when the contract is deployed.
-- Optionally without `export` enabled, contract functions will not be exported.
-Types will be still exposed, which is useful when developing multiple contracts
-together and this contract is to be imported into another but its functions are
-not intended to be invoked.
-- And `testutils` which will cause additional test utilities to be generated for
-calling the contract in tests. The library itself is added as a `dev_dependencies`
-so that whenever its tests are running the `testutils` feature is enabled.
+The `features` list includes a `testutils` feature, which will cause additional
+test utilities to be generated for calling the contract in tests. The test
+utilities are automatically available inside Rust unit tests inside the same
+crate as your contract. If you write Rust integration tests, or write tests from
+another crate, you'll need to use the `testutils` feature to be able to use
+those test utilities.
 
 The config for the `release` profile configures the Rust toolchain to produce
 smaller contracts.
@@ -81,33 +74,33 @@ Open the `src/lib.rs` file, and copy-paste the following code.
 
 ```rust
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+use soroban_sdk::{contractimpl, symbol, vec, Env, Symbol, Vec};
 
 pub struct Contract;
 
-#[contractimpl(export_if = "export")]
+#[contractimpl]
 impl Contract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        const GREETING: Symbol = Symbol::from_str("Hello");
-        vec![&env, GREETING, to]
+        vec![&env, symbol!("Hello"), to]
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{Contract, hello};
-    use soroban_sdk::{vec, Env, FixedBinary, Symbol};
+    use super::{Contract, ContractClient};
+    use soroban_sdk::{symbol, vec, BytesN, Env, Symbol};
 
     #[test]
     fn test() {
         let env = Env::default();
-        let contract_id = FixedBinary::from_array(&env, [0; 32]);
+        let contract_id = BytesN::from_array(&env, [0; 32]);
         env.register_contract(&contract_id, Contract);
+        let client = ContractClient::new(&env, &contract_id);
 
-        let words = hello::invoke(&env, &contract_id, &Symbol::from_str("Dev"));
+        let words = client.hello(symbol!("Dev"));
         assert_eq!(
             words,
-            vec![&env, Symbol::from_str("Hello"), Symbol::from_str("Dev"),]
+            vec![&env, symbol!("Hello"), symbol!("Dev"),]
         );
     }
 }


### PR DESCRIPTION
### What
Remove export feature, explain testutils feature better, and update examples to use new types.

### Why
The SDK has new types. The export feature is not particularly relevant to a developer at this stage and is for rather advanced usage. The testutils feature needs better instruction on how to use it in Rust integration tests (https://github.com/stellar/soroban-docs/issues/86).