### PR TITLE
Fix title capitalization of built-in contracts page

### DIFF
--- a/docs/built-in-contracts/_category_.json
+++ b/docs/built-in-contracts/_category_.json
@@ -1,6 +1,6 @@
 {
   "position": 3,
-  "label": "Built-In Contracts",
+  "label": "Built-in Contracts",
   "link": {
     "type": "generated-index"
   }


### PR DESCRIPTION
### What
Change `Built-In` to `Built-in`.

### Why
The `in` shouldn't normally be capitalized in a title.

See https://capitalizemytitle.com.