### PR TITLE
Instruct users to checkout v0.0.4 tag for examples

### DIFF
--- a/docs/examples/authorization.mdx
+++ b/docs/examples/authorization.mdx
@@ -8,7 +8,7 @@ verifies an `Identifiers` signature before proceeding with the rest of the
 function. In this example, data is stored under an `Identifier` after
 authorization has been verified. 
 
-[authorization example]: https://github.com/stellar/soroban-examples/tree/main/authorization
+[authorization example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/authorization
 
 ## Run the Example
 
@@ -18,7 +18,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `authorization` directory, and use `cargo test`.
@@ -125,7 +125,7 @@ impl ExampleContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/main/authorization
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/authorization
 
 ## Authorization semantics
 

--- a/docs/examples/authorization.mdx
+++ b/docs/examples/authorization.mdx
@@ -13,7 +13,7 @@ authorization has been verified.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -14,7 +14,7 @@ tooling is still building out the tools to support these workflows. Feedback
 appreciated [here](https://github.com/stellar/rs-soroban-sdk/issues/new/choose).
 :::
 
-[cross contract call example]: https://github.com/stellar/soroban-examples/tree/main/cross_contract_calls
+[cross contract call example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/cross_contract_calls
 
 ## Run the Example
 
@@ -24,7 +24,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `cross_contract/contract_b`
@@ -71,7 +71,7 @@ impl ContractB {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/main/cross_contract
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/cross_contract
 
 ## How it Works
 

--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -19,7 +19,7 @@ appreciated [here](https://github.com/stellar/rs-soroban-sdk/issues/new/choose).
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -12,7 +12,7 @@ invocations.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -7,7 +7,7 @@ The [custom types example] demonstrates how to define your own data structures
 that can be stored on the ledger, or used as inputs and outputs to contract
 invocations.
 
-[custom types example]: https://github.com/stellar/soroban-examples/tree/main/custom_types
+[custom types example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/custom_types
 
 ## Run the Example
 
@@ -17,7 +17,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `custom_types` directory, and use `cargo test`.
@@ -70,7 +70,7 @@ impl CustomTypesContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/main/custom_types
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/custom_types
 
 ## How it Works
 

--- a/docs/examples/events.mdx
+++ b/docs/examples/events.mdx
@@ -10,7 +10,7 @@ The [events example] demonstrates how to publish events from a contract.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/events.mdx
+++ b/docs/examples/events.mdx
@@ -5,7 +5,7 @@ title: Events
 
 The [events example] demonstrates how to publish events from a contract.
 
-[events example]: https://github.com/stellar/soroban-examples/tree/main/events
+[events example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/events
 
 ## Run the Example
 
@@ -15,7 +15,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `events` directory, and use `cargo test`.
@@ -50,7 +50,7 @@ impl EventsContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/main/events
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/events
 
 ## How it Works
 
@@ -58,7 +58,7 @@ This example contract is similar to the [hello world example]. It also contains 
 contract function named `hello`. However, instead of returning the greeting message to the caller, it 
 publishes the message (along with some data) as a contract event.
 
-[hello world example]: https://github.com/stellar/soroban-examples/tree/main/hello_world
+[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/hello_world
 
 Contract events let smart contract developers emit information about what their
 contract is doing.

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -6,7 +6,7 @@ title: Hello World
 The [hello world example] demonstrates how to write a simple contract, with a
 single function that takes one input and returns it as an output.
 
-[hello world example]: https://github.com/stellar/soroban-examples/tree/main/hello_world
+[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/hello_world
 
 ## Run the Example
 
@@ -16,7 +16,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `hello_world` directory, and use `cargo test`.
@@ -48,7 +48,7 @@ impl HelloContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/main/hello_world
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/hello_world
 
 ## How it Works
 

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -11,7 +11,7 @@ single function that takes one input and returns it as an output.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -6,7 +6,7 @@ title: Increment
 The [increment example] demonstrates how to write a simple contract, with a
 single function that increments an internal counter and returns the value.
 
-[increment example]: https://github.com/stellar/soroban-examples/tree/main/increment
+[increment example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/increment
 
 ## Run the Example
 
@@ -16,7 +16,7 @@ configured, then clone the examples repository:
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone https://github.com/stellar/soroban-examples
+git clone -b v0.0.4 https://github.com/stellar/soroban-examples
 ```
 
 To run the tests for the example, navigate to the `increment` directory, and use `cargo test`.
@@ -54,7 +54,7 @@ impl IncrementContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/main/increment
+Ref: https://github.com/stellar/soroban-examples/tree/v0.0.4/increment
 
 ## How it Works
 

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -11,7 +11,7 @@ single function that increments an internal counter and returns the value.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the examples repository:
+configured, then clone the `v0.0.4` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 

--- a/docs/examples/liquidity-pool.mdx
+++ b/docs/examples/liquidity-pool.mdx
@@ -8,4 +8,4 @@ liquidity pool contract. The comments in the [source code] explain how the contr
 be used.
 
 [liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/liquidity_pool
-[source code]: https://github.com/stellar/soroban-examples/blob/main/liquidity_pool/src/lib.rs#L143
+[source code]: https://github.com/stellar/soroban-examples/blob/v0.0.4/liquidity_pool/src/lib.rs#L143

--- a/docs/examples/liquidity-pool.mdx
+++ b/docs/examples/liquidity-pool.mdx
@@ -7,5 +7,5 @@ The [liquidity pool example] demonstrates how to write a constant product
 liquidity pool contract. The comments in the [source code] explain how the contract should
 be used.
 
-[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/main/liquidity_pool
+[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/liquidity_pool
 [source code]: https://github.com/stellar/soroban-examples/blob/main/liquidity_pool/src/lib.rs#L143

--- a/docs/examples/single-offer-sale.mdx
+++ b/docs/examples/single-offer-sale.mdx
@@ -7,5 +7,5 @@ The [single offer sale example] demonstrates how to write a contract that allows
 a seller to set up an offer to sell token A for token B. The comments in the
 [source code] explain how the contract should be used.
 
-[single offer sale example]: https://github.com/stellar/soroban-examples/tree/main/single_offer
+[single offer sale example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/single_offer
 [source code]: https://github.com/stellar/soroban-examples/blob/main/single_offer/src/lib.rs#L131

--- a/docs/examples/single-offer-sale.mdx
+++ b/docs/examples/single-offer-sale.mdx
@@ -8,4 +8,4 @@ a seller to set up an offer to sell token A for token B. The comments in the
 [source code] explain how the contract should be used.
 
 [single offer sale example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/single_offer
-[source code]: https://github.com/stellar/soroban-examples/blob/main/single_offer/src/lib.rs#L131
+[source code]: https://github.com/stellar/soroban-examples/blob/v0.0.4/single_offer/src/lib.rs#L131

--- a/docs/examples/token.mdx
+++ b/docs/examples/token.mdx
@@ -6,5 +6,5 @@ title: Token
 The [token example] demonstrates how to write a token contract that implements
 the same logic as the [built-in token contract].
 
-[token example]: https://github.com/stellar/soroban-token-contract/tree/main/
+[token example]: https://github.com/stellar/soroban-token-contract/tree/v0.0.4/
 [built-in token contract]: ../built-in-contracts/token-contract


### PR DESCRIPTION
### What
Instruct users to checkout v0.0.4 tag for examples.

### Why
We tried having a dev branch but it became a more significant overhead than I think we should maintain. @MonsieurNicolas also pointed out these repos don't have snapshots and so we're adding tags to these repos anyway. To lower our overhead we should just lean on the tags. With these changes to the docs it is not so bad an ask for users and arguably not the most complex thing contract developers will come up against.