### PR TITLE
Add a build-your-own SDK page

### DIFF
--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -77,7 +77,6 @@ guarantee exists at this time.
    There should be a `SCSpecEntry` for every function, struct, and union
    exported by the contract.
 
-
 ## Testing
 
 Any Soroban SDK ideally provides a test environment for executing contract functions in the context of a Soroban runtime environment. The [soroban-sdk] does this by embedding the Soroban environment Rust library, [soroban-env-host].

--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -79,7 +79,9 @@ guarantee exists at this time.
 
 ## Testing
 
-Any Soroban SDK ideally provides a test environment for executing contract functions in the context of a Soroban runtime environment. The [soroban-sdk] does this by embedding the Soroban environment Rust library, [soroban-env-host].
+Any Soroban SDK ideally provides a test environment for executing contract
+functions in the context of a Soroban runtime environment. The [soroban-sdk]
+does this by embedding the Soroban environment Rust library, [soroban-env-host].
 
 The test environment should include:
 

--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -3,8 +3,6 @@ sidebar_position: 3
 title: Build Your Own
 ---
 
-# SDK: How to BYO (Build Your Own)
-
 Soroban currently has one SDK for writing contracts in Rust, which can be found
 [here][soroban-sdk].
 

--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Build Your Own
+title: Build Your Own SDK
 ---
 
 Soroban currently has one SDK for writing contracts in Rust, which can be found
@@ -21,19 +21,19 @@ guarantee exists at this time.
 
 ## Functionality
 
-1. Value conversions
+### Value Conversions
 
    - [RawVal] encode/decode
    - [Object] encode/decode
    - [Symbol] encode/decode
 
-3. Host functions
+### Host Functions
 
    The host functions defined in [env.rs] are functions callable from within the
    WASM Guest environment. These need to be available to contracts to call, in
    some form, ideally wrapped so that contracts have a nicer interface.
 
-5. SDK Types
+### SDK Types
 
    All the types in [soroban-sdk](https://docs.rs/soroban-sdk) should be
    supported. Notably:
@@ -42,7 +42,7 @@ guarantee exists at this time.
    - [Bytes]
    - [BigInt]
 
-1. User Defined Types
+### User Defined Types
 
    Contracts should be able to create user defined types, such as structs or
    unions, and have them be transmitted to the host for storing and transmitted
@@ -59,13 +59,13 @@ guarantee exists at this time.
    and zero or one additional elements representing a value stored with the
    variant.
 
-7. Meta generation
+### Meta Generation
 
    Contracts must contain a WASM custom section with name `contractenvmetav0`
    and containing a serialized [`SCEnvMetaEntry`].  The interface version stored
    within should match the version of the host functions supported.
 
-9. Contract spec generation
+### Contract Spec Generation
 
    Contracts should contain a WASM custom section with name `contractspecv0` and
    containing a serialized stream of [`SCSpecEntry`].  There should be a

--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -1,0 +1,101 @@
+---
+sidebar_position: 3
+title: Build Your Own
+---
+
+# SDK: How to BYO (Build Your Own)
+
+Soroban currently has one SDK for writing contracts in Rust, which can be found
+[here][soroban-sdk].
+
+To build SDKs for other languages a few things need to be included in the SDK to
+provide contracts with the foundation they need to accept inputs, decode them,
+store data, call other contracts, etc.
+
+Below is a list of functionality a Soroban SDK needs to support those things, as
+well as some details on what an SDK can provide in regards to testing
+capabilities.
+
+:::caution
+The Soroban environment is under active development and API compatibility exists
+guarantee exists at this time.
+:::
+
+## Functionality
+
+1. Value conversions
+
+   - [RawVal] encode/decode
+   - [Object] encode/decode
+   - [Symbol] encode/decode
+
+3. Host functions
+
+   The host functions defined in [env.rs] are functions callable from within the
+   WASM Guest environment. These need to be available to contracts to call, in
+   some form, ideally wrapped so that contracts have a nicer interface.
+
+5. SDK Types
+
+   All the types in [soroban-sdk](https://docs.rs/soroban-sdk) should be
+   supported. Notably:
+   - [Map]
+   - [Vec]
+   - [Bytes]
+   - [BigInt]
+
+1. User Defined Types
+
+   Contracts should be able to create user defined types, such as structs or
+   unions, and have them be transmitted to the host for storing and transmitted
+   back for loading.
+
+   SDKs do this by converting objects to and from a `Val`. In the [soroban-sdk]
+   this is referred to as a [RawVal].
+
+   Structs with named fields should be translated into a `Map` with keys as
+   `Symbol`s and the values as the field value, i.e. `Map<Symbol, V>`.
+
+   Unions (or enums in some languages) with named variants should be translated
+   into a `Vec` with the first element as a `Symbol` of the name of the variant,
+   and zero or one additional elements representing a value stored with the
+   variant.
+
+7. Meta generation
+
+   Contracts must contain a WASM custom section with name `contractenvmetav0`
+   and containing a serialized
+   [`SCEnvMetaEntry`](https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-env-meta.x).
+   The interface version stored within should match the version of the host
+   functions supported.
+
+9. Contract spec generation
+
+   Contracts should contain a WASM custom section with name `contractspecv0` and
+   containing a serialized stream of
+   [`SCSpecEntry`](https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-spec.x).
+   There should be a `SCSpecEntry` for every function, struct, and union
+   exported by the contract.
+
+
+## Testing
+
+Any Soroban SDK ideally provides a test environment for executing contract functions in the context of a Soroban runtime environment. The [soroban-sdk] does this by embedding the Soroban environment Rust library, [soroban-env-host].
+
+The test environment should include:
+
+- Invoking contract functions.
+- Integration testing across multiple contracts.
+
+[soroban-sdk]: https://docs.rs/soroban-sdk.
+[soroban-env-host]: https://github.com/stellar/rs-soroban-env
+[RawVal]: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-common/src/raw_val.rs
+[Object]: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-common/src/object.rs
+[Symbol]: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-common/src/symbol.rs
+[env.rs]: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-common/src/env.rs
+[Map]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/map.rs
+[Vec]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/vec.rs
+[Bytes]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/bytes.rs
+[BigInt]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/bigint.rs
+[`SCEnvMetaEntry`]: https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-env-meta.x
+[`SCSpecEntry`]: https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-spec.x

--- a/docs/SDKs/byo.mdx
+++ b/docs/SDKs/byo.mdx
@@ -64,18 +64,14 @@ guarantee exists at this time.
 7. Meta generation
 
    Contracts must contain a WASM custom section with name `contractenvmetav0`
-   and containing a serialized
-   [`SCEnvMetaEntry`](https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-env-meta.x).
-   The interface version stored within should match the version of the host
-   functions supported.
+   and containing a serialized [`SCEnvMetaEntry`].  The interface version stored
+   within should match the version of the host functions supported.
 
 9. Contract spec generation
 
    Contracts should contain a WASM custom section with name `contractspecv0` and
-   containing a serialized stream of
-   [`SCSpecEntry`](https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-spec.x).
-   There should be a `SCSpecEntry` for every function, struct, and union
-   exported by the contract.
+   containing a serialized stream of [`SCSpecEntry`].  There should be a
+   `SCSpecEntry` for every function, struct, and union exported by the contract.
 
 ## Testing
 


### PR DESCRIPTION
### What
Add a build-your-own SDK page.

### Why
@tomerweller made the suggestion that we should point people in the right direction if they're wanting to build an SDK. This document should provide enough level of detail to get someone started, without dictating too specifically exactly what the shape of an SDK should take. It also doesn't go into so much detail that this page would go out of date quickly.

Close https://github.com/stellar/soroban-docs/issues/10