### PR TITLE
Add rust-src component install to build optimized tutorial

### DIFF
--- a/docs/tutorials/build-optimized.mdx
+++ b/docs/tutorials/build-optimized.mdx
@@ -30,6 +30,7 @@ To install the nightly Rust toolchain use `rustup`.
 ```sh
 rustup install nightly
 rustup target add --toolchain nightly wasm32-unknown-unknown
+rustup component add --toolchain nightly rust-src
 ```
 
 ## Install `wasm-opt`


### PR DESCRIPTION
### What
Add rust-src component install to build optimized tutorial

### Why
The rust-src is not installed by default but is required by the later step in the tutorial that rebuilds the rust-src with a feature enabled.

Thanks to @nano-o for identifying this was missing from the tutorial.