### PR TITLE
Add mention of EIP-2612 in adv auth example

### DIFF
--- a/docs/SDKs/rust-auth.mdx
+++ b/docs/SDKs/rust-auth.mdx
@@ -4,8 +4,10 @@ title: Soroban Rust Auth SDK
 ---
 
 The `soroban-auth` Rust crate contains the Soroban Rust Auth SDK. It provides
-types and utilities for authenticating participants in a variety of ways including:
-- Authenticating by being the invoker, as an account ID or a contract.
+types and utilities for authenticating participants in a variety of ways
+including:
+- Authenticating by being the invoker, as an transaction source account or a
+contract.
 - Presigned invocations with account signers or ed25519 keys, similar to
 [EIP-2612] and [EIP-712] in the Ethereum ecosystem.
 

--- a/docs/examples/auth-advanced.mdx
+++ b/docs/examples/auth-advanced.mdx
@@ -3,19 +3,26 @@ sidebar_position: 7
 title: Auth (Advanced)
 ---
 
-The [advanced auth example] demonstrates how to write a contract that
-verifies presigned invocations using the [soroban-auth] crate.
+The [advanced auth example] demonstrates how to write a contract that supports
+multiple forms of authentication using the [soroban-auth] crate.
+
+The example supports authentication by:
+- Being the invoker, as a transaction source account or a contract.
+- Presigned invocations with account signers or ed25519 keys, similar to
+[EIP-2612] and [EIP-712] in the Ethereum ecosystem.
+
+[EIP-2612]: https://eips.ethereum.org/EIPS/eip-2612
+[EIP-712]: https://eips.ethereum.org/EIPS/eip-712
 
 Participants are identified with `Identifier`'s, that are a superset of an
-`Address`. Participants can be identified by being the invoker, or by presigning
-invocations. Both are provided by specifying a `Siganture` as an argument.
-
-An `Identifier` can represent an:
+`Address`. An `Identifier` can represent an:
 - Account ID
 - Contract ID
 - Ed25519 key
 
-A `Signature` can be a:
+Participants specify how they are authenticating, and provide authentication by
+including a `Siganture` as an argument in the invocation. A `Signature` can be
+a:
 - Invoker — An invoking address (account ID or contract ID).
 - Account – An invocation presigned with account signers.
 – Ed25519 – An invocation presigned with an ed25519 key.


### PR DESCRIPTION
### What
Add mention of EIP-2612 in adv auth example.

### Why
