### PR TITLE
Fix mistakes in examples in docs

### DIFF
--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -178,7 +178,7 @@ let env = Env::default();
 The contract is registered with the environment using the contract type.
 
 ```rust
-env.register_contract(&contract_id, CustomTypesContract);
+let contract_id = env.register_contract(None, CustomTypesContract);
 ```
 
 All public functions within an `impl` block that is annotated with the

--- a/docs/examples/errors.mdx
+++ b/docs/examples/errors.mdx
@@ -232,7 +232,7 @@ let env = Env::default();
 The contract is registered with the environment using the contract type.
 
 ```rust
-env.register_contract(&contract_id, IncrementContract);
+let contract_id = env.register_contract(None, IncrementContract);
 ```
 
 All public functions within an `impl` block that is annotated with the

--- a/docs/examples/increment.mdx
+++ b/docs/examples/increment.mdx
@@ -136,7 +136,7 @@ let env = Env::default();
 The contract is registered with the environment using the contract type.
 
 ```rust
-env.register_contract(&contract_id, IncrementContract);
+let contract_id = env.register_contract(None, IncrementContract);
 ```
 
 All public functions within an `impl` block that is annotated with the


### PR DESCRIPTION
### What
Fix mistakes in examples in docs.

### Why
Some of these function calls were changed in the actual examples, but not in the docs.