### PR TITLE
Reorder examples

### DIFF
--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 4
 title: Custom Types
 ---
 

--- a/docs/examples/errors.mdx
+++ b/docs/examples/errors.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Errors
 ---
 

--- a/docs/examples/events.mdx
+++ b/docs/examples/events.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 3
 title: Events
 ---
 

--- a/docs/examples/logging.mdx
+++ b/docs/examples/logging.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 title: Logging
 ---
 

--- a/docs/examples/storing-data.mdx
+++ b/docs/examples/storing-data.mdx
@@ -1,10 +1,11 @@
 ---
 sidebar_position: 2
-title: Increment
+title: Storing Data
 ---
 
-The [increment example] demonstrates how to write a simple contract, with a
-single function that increments an internal counter and returns the value.
+The [increment example] demonstrates how to write a simple contract that stores
+data, with a single function that increments an internal counter and returns the
+value.
 
 [increment example]: https://github.com/stellar/soroban-examples/tree/v0.0.4/increment
 
@@ -44,12 +45,12 @@ pub struct IncrementContract;
 impl IncrementContract {
     pub fn increment(env: Env) -> u32 {
         let mut count: u32 = env
-            .contract_data()
+            .data()
             .get(COUNTER)
             .unwrap_or(Ok(0)) // If no value set, assume 0.
             .unwrap(); // Panic if the value of COUNTER is not u32.
         count += 1;
-        env.contract_data().set(COUNTER, count);
+        env.data().set(COUNTER, count);
         count
     }
 }
@@ -76,7 +77,7 @@ const COUNTER: Symbol = symbol!("COUNTER");
 
 ### Contract Data Access
 
-The `Env` `contract_data()` function is used to retrieve access and update a
+The `Env` `data()` function is used to retrieve access and update a
 counter. The executing contract is the only contract that can query or modify
 contract data that it has stored. The data stored is viewable on ledger anywhere
 the ledger is viewable, but contracts executing within the Soroban environment
@@ -86,7 +87,7 @@ The `get()` function gets the current value associated with the counter key.
 
 ```rust
 let mut count: u32 = env
-    .contract_data()
+    .data()
     .get(COUNTER)
     .unwrap_or(Ok(0)) // If no value set, assume 0.
     .unwrap(); // Panic if the value of COUNTER is not u32.
@@ -106,7 +107,7 @@ The `set()` function stores the new count value against the key, replacing the
 existing value.
 
 ```rust
-env.contract_data().set(COUNTER, count);
+env.data().set(COUNTER, count);
 ```
 
 ## Tests


### PR DESCRIPTION
### What
Reorder examples.

### Why
So that they tell an iterative narrative.