### PR TITLE
Compact the error example to match other examples

### DIFF
--- a/docs/examples/errors.mdx
+++ b/docs/examples/errors.mdx
@@ -74,29 +74,18 @@ pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
-    /// Increment increments an internal counter, and returns the value. Errors
-    /// if the value is attempted to be incremented past 5.
     pub fn increment(env: Env) -> Result<u32, Error> {
-        // Get the current count.
         let mut count: u32 = env
             .data()
             .get(COUNTER)
             .unwrap_or(Ok(0)) // If no value set, assume 0.
             .unwrap(); // Panic if the value of COUNTER is not u32.
         log!(&env, "count: {}", count);
-
-        // Increment the count.
         count += 1;
-
-        // Check if the count exceeds the max.
         if count <= MAX {
-            // Save the count.
             env.data().set(COUNTER, count);
-
-            // Return the count to the caller.
             Ok(count)
         } else {
-            // Return an error if the max is exceeded.
             Err(Error::LimitReached)
         }
     }


### PR DESCRIPTION
### What
Compact the error example.

### Why
To match the form of other examples. Since the page describes the example the comments are less critical. The comments remain in the actual example since the page isn't present there.