### PR TITLE
Move timelock example to be higher up in the example list

### DIFF
--- a/docs/examples/liquidity-pool.mdx
+++ b/docs/examples/liquidity-pool.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: Liquidity Pool
 ---
 

--- a/docs/examples/single-offer-sale.mdx
+++ b/docs/examples/single-offer-sale.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: Single Offer Sale
 ---
 

--- a/docs/examples/timelock.mdx
+++ b/docs/examples/timelock.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 11
 title: Timelock
 ---
 


### PR DESCRIPTION
### What
Move timelock example to be higher up in the example list.

### Why
It is an easier to understand contract than some of the others that proceed it in the list. The list is ordered by difficulty, so that a reader who decides to iterate through them has a gradual learning curve.