### PR TITLE
Remove out-dated recommendation about testutils feature

### DIFF
--- a/docs/tutorials/testing.mdx
+++ b/docs/tutorials/testing.mdx
@@ -59,16 +59,6 @@ fn test() {
 </TabItem>
 </Tabs>
 
-:::info
-The above example is a [Rust unit test] that lives inside the `src/` directory.
-Note that if you place the test in the `tests/` directory it becomes a [Rust
-integration test] with the test being compiled separately. Integration tests
-require `#![cfg(feature = "testutils")]` at the top of the file and to be run
-with the `testutils` feature enabled, e.g. `cargo test --features testutils`, to
-enable the generated Soroban test utilities.
-:::
-
-
 In any test the first thing that is always required is an `Env`, which is the
 Soroban environment that the contract will run inside of.
 


### PR DESCRIPTION
### What
Remove out-dated recommendation about testutils feature.

### Why
It is out-dated information.