### PR TITLE
Update soroban-cli to v0.1.2

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -54,7 +54,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```sh
-cargo install --locked --version 0.1.1 soroban-cli
+cargo install --locked --version 0.1.2 soroban-cli
 ```
 
 :::info
@@ -72,7 +72,7 @@ soroban
 
 ```
 ❯ soroban -h
-soroban 0.1.1
+soroban 0.1.2
 https://soroban.stellar.org
 
 USAGE:


### PR DESCRIPTION
### What
Update soroban-cli to v0.1.2.

### Why
https://github.com/stellar/soroban-cli/releases/tag/v0.1.2