### PR TITLE
move Optimized Builds out of collapsed section

### DIFF
--- a/docs/tutorials/build.mdx
+++ b/docs/tutorials/build.mdx
@@ -26,11 +26,7 @@ specification that can be imported into other contracts who wish to call it.
 This is the only artifact needed to deploy the contract, share the interface
 with others, or integration test against the contract.
 
-<details><summary>Optimizing Builds</summary>
-<p>
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+# Optimizing Builds
 
 Building optimized contracts to be as small as possible requires some additional
 tools, and requires installing the `nightly` Rust toolchain and `wasm-opt`.


### PR DESCRIPTION
So that it can be linked to