### PR TITLE
Fix return type in example code snippets

### DIFF
--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -44,7 +44,7 @@ pub struct HelloContract;
 #[contractimpl]
 impl HelloContract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol!("Hello"), to]
+        vec![&env, symbol!("Hello"), to].into()
     }
 }
 ```

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -96,7 +96,7 @@ pub struct Contract;
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol!("Hello"), to]
+        vec![&env, symbol!("Hello"), to].into()
     }
 }
 


### PR DESCRIPTION
Some IDEs (e.g. intelliJ) complain about the return type of the `vec!` macro not matching the declared return type.
Even though it compiles and runs successfully this is confusing for rust-newbies (like me).

![image](https://user-images.githubusercontent.com/1752217/197525100-4f365e47-dd9d-427e-85bd-e255101f093f.png)
