### PR TITLE
Add gitpod links

### DIFF
--- a/docs/examples/auth-advanced.mdx
+++ b/docs/examples/auth-advanced.mdx
@@ -73,8 +73,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `auth_advanced` directory, and use `cargo test`.
 

--- a/docs/examples/auth-advanced.mdx
+++ b/docs/examples/auth-advanced.mdx
@@ -6,6 +6,9 @@ title: Auth (Advanced)
 The [advanced auth example] demonstrates how to write a contract that supports
 multiple forms of authentication using the [soroban-auth] crate.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 The example supports authentication by:
 - Being the invoker, as a transaction source account or a contract.
 - Presigned invocations with account signers or ed25519 keys, similar to
@@ -57,18 +60,21 @@ is appropriate for themselves.
 
 [soroban-auth]: ../SDKs/rust-auth
 [auth example]: auth.mdx
-[advanced auth example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/auth_advanced
+[advanced auth example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/auth_advanced
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `auth_advanced` directory, and use `cargo test`.
 
@@ -195,7 +201,7 @@ fn set_nonce(env: &Env, id: &Identifier, nonce: BigInt) {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/auth_advanced
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/auth_advanced
 
 ## How it Works
 

--- a/docs/examples/auth.mdx
+++ b/docs/examples/auth.mdx
@@ -7,7 +7,10 @@ The [auth example] demonstrates how to tell who has invoked a contract, and
 verify that a contract has been invoked by an account or contract. This example
 is an extension of the [storing data example].
 
-[events example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/events
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[events example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/events
 [storing data example]: storing-data.mdx
 
 The participant who invoked a contract is an `Address` containing one-of a:
@@ -23,19 +26,22 @@ invocations, or ed25519 keys independent of accounts and contracts, see the
 [advanced auth example].
 :::
 
-[auth example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/auth
+[auth example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/auth
 [advanced auth example]: auth-advanced.mdx
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `auth` directory, and use
 `cargo test`.
@@ -90,7 +96,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/auth
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/auth
 
 ## How it Works
 

--- a/docs/examples/auth.mdx
+++ b/docs/examples/auth.mdx
@@ -40,8 +40,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `auth` directory, and use
 `cargo test`.

--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -6,6 +6,9 @@ title: Cross Contract Calls
 The [cross contract call example] demonstrates how to call a contract from
 another contract.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 :::info
 In this example there are two contracts that are compiled separately, deployed
 separately, and then tested together. There are a variety of ways to develop and
@@ -14,18 +17,21 @@ tooling is still building out the tools to support these workflows. Feedback
 appreciated [here](https://github.com/stellar/rs-soroban-sdk/issues/new/choose).
 :::
 
-[cross contract call example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/cross_contract_calls
+[cross contract call example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/cross_contract_calls
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `cross_contract/contract_b`
 directory, and use `cargo test`.
@@ -71,7 +77,7 @@ impl ContractB {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/cross_contract
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/cross_contract
 
 ## How it Works
 

--- a/docs/examples/cross-contract-call.mdx
+++ b/docs/examples/cross-contract-call.mdx
@@ -30,8 +30,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `cross_contract/contract_b`
 directory, and use `cargo test`.

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -7,19 +7,25 @@ The [custom types example] demonstrates how to define your own data structures
 that can be stored on the ledger, or used as inputs and outputs to contract
 invocations. This example is an extension of the [storing data example].
 
-[custom types example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/custom_types
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[custom types example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/custom_types
 [storing data example]: storing-data.mdx
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `custom_types` directory, and use `cargo test`.
 
@@ -68,7 +74,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/custom_types
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/custom_types
 
 ## How it Works
 

--- a/docs/examples/custom-types.mdx
+++ b/docs/examples/custom-types.mdx
@@ -24,8 +24,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `custom_types` directory, and use `cargo test`.
 

--- a/docs/examples/deployer.mdx
+++ b/docs/examples/deployer.mdx
@@ -5,23 +5,29 @@ title: Deployer
 
 The [deployer example] demonstrates how to deploy contracts using a contract.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 :::info
 In this example there are two contracts that are compiled separately, and the
 tests deploy one with the other.
 :::
 
-[deployer example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/deployer
+[deployer example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/deployer
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `deployer/deployer`
 directory, and use `cargo test`.
@@ -60,7 +66,7 @@ impl Deployer {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/deployer
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/deployer
 
 ## How it Works
 

--- a/docs/examples/deployer.mdx
+++ b/docs/examples/deployer.mdx
@@ -26,8 +26,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `deployer/deployer`
 directory, and use `cargo test`.

--- a/docs/examples/errors.mdx
+++ b/docs/examples/errors.mdx
@@ -24,8 +24,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `errors` directory, and use `cargo test`.
 

--- a/docs/examples/errors.mdx
+++ b/docs/examples/errors.mdx
@@ -7,19 +7,25 @@ The [errors example] demonstrates how to define and generate errors in a
 contract that invokers of the contract can understand and handle. This example
 is an extension of the [storing data example].
 
-[errors example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/errors
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[errors example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/errors
 [storing data example]: storing-data.mdx
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `errors` directory, and use `cargo test`.
 
@@ -91,7 +97,7 @@ impl IncrementContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/errors
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/errors
 
 ## How it Works
 

--- a/docs/examples/events.mdx
+++ b/docs/examples/events.mdx
@@ -6,19 +6,25 @@ title: Events
 The [events example] demonstrates how to publish events from a contract.  This
 example is an extension of the [storing data example].
 
-[events example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/events
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[events example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/events
 [storing data example]: storing-data.mdx
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `events` directory, and use `cargo test`.
 
@@ -56,7 +62,7 @@ impl IncrementContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/events
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/events
 
 ## How it Works
 

--- a/docs/examples/events.mdx
+++ b/docs/examples/events.mdx
@@ -23,8 +23,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `events` directory, and use `cargo test`.
 

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -6,18 +6,24 @@ title: Hello World
 The [hello world example] demonstrates how to write a simple contract, with a
 single function that takes one input and returns it as an output.
 
-[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/hello_world
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/hello_world
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `hello_world` directory, and use `cargo test`.
 
@@ -48,7 +54,7 @@ impl HelloContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/hello_world
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/hello_world
 
 ## How it Works
 

--- a/docs/examples/hello-world.mdx
+++ b/docs/examples/hello-world.mdx
@@ -22,8 +22,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `hello_world` directory, and use `cargo test`.
 

--- a/docs/examples/liquidity-pool.mdx
+++ b/docs/examples/liquidity-pool.mdx
@@ -7,5 +7,8 @@ The [liquidity pool example] demonstrates how to write a constant product
 liquidity pool contract. The comments in the [source code] explain how the contract should
 be used.
 
-[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/liquidity_pool
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/liquidity_pool
 [source code]: https://github.com/stellar/soroban-examples/blob/v0.1.0/liquidity_pool/src/lib.rs#L143

--- a/docs/examples/logging.mdx
+++ b/docs/examples/logging.mdx
@@ -5,11 +5,14 @@ title: Logging
 
 The [logging example] demonstrates how to log for the purpose of debugging.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 Logs in contracts are only visible in tests, or when executing contracts using
 [`soroban-cli`]. Logs are only compiled into the contract if the
 `debug-assertions` Rust compiler option is enabled.
 
-[logging example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/hello_world
+[logging example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/hello_world
 
 :::tip
 Logs are no a substitute for step-through debugging. Rust tests for Soroban can
@@ -28,13 +31,16 @@ example] for how to produce structured events.
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `logging` directory, and use
 `cargo test`.
@@ -73,7 +79,7 @@ impl Contract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/logging
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/logging
 
 ## How it Works
 

--- a/docs/examples/logging.mdx
+++ b/docs/examples/logging.mdx
@@ -39,8 +39,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `logging` directory, and use
 `cargo test`.

--- a/docs/examples/multisig-wallet.mdx
+++ b/docs/examples/multisig-wallet.mdx
@@ -6,10 +6,13 @@ title: Multisig Wallet
 The [multisig wallet example] demonstrates a complex auth scheme with multiple
 signers that authorizes payments either immediately or in a delayed async fashion.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 :::tip
 Stellar supports [multisig accounts] natively, and multisig accounts may be
 simpler to manage than a contract driven multisig wallet.
 :::
 
-[multisig wallet example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/wallet
+[multisig wallet example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/wallet
 [multisig accounts]: https://developers.stellar.org/docs/encyclopedia/signatures-multisig

--- a/docs/examples/single-offer-sale.mdx
+++ b/docs/examples/single-offer-sale.mdx
@@ -7,5 +7,8 @@ The [single offer sale example] demonstrates how to write a contract that allows
 a seller to set up an offer to sell token A for token B. The comments in the
 [source code] explain how the contract should be used.
 
-[single offer sale example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/single_offer
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[single offer sale example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/single_offer
 [source code]: https://github.com/stellar/soroban-examples/blob/v0.1.0/single_offer/src/lib.rs#L131

--- a/docs/examples/storing-data.mdx
+++ b/docs/examples/storing-data.mdx
@@ -7,18 +7,24 @@ The [increment example] demonstrates how to write a simple contract that stores
 data, with a single function that increments an internal counter and returns the
 value.
 
-[increment example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/increment
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
+[increment example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/increment
 
 ## Run the Example
 
 First go through the [Setup] process to get your development environment
-configured, then clone the `v0.1.0` tag of `soroban-examples` repository:
+configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 
 [Setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v0.1.0 https://github.com/stellar/soroban-examples
+git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
+
+Or, skip the development environment setup and open this example in Gitpod.  
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
 To run the tests for the example, navigate to the `increment` directory, and use `cargo test`.
 
@@ -59,7 +65,7 @@ impl IncrementContract {
     }
 }
 ```
-Ref: https://github.com/stellar/soroban-examples/tree/v0.1.0/increment
+Ref: https://github.com/stellar/soroban-examples/tree/v0.1.1/increment
 
 ## How it Works
 

--- a/docs/examples/storing-data.mdx
+++ b/docs/examples/storing-data.mdx
@@ -23,8 +23,7 @@ configured, then clone the `v0.1.1` tag of `soroban-examples` repository:
 git clone -b v0.1.1 https://github.com/stellar/soroban-examples
 ```
 
-Or, skip the development environment setup and open this example in Gitpod.  
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
 To run the tests for the example, navigate to the `increment` directory, and use `cargo test`.
 

--- a/docs/examples/timelock.mdx
+++ b/docs/examples/timelock.mdx
@@ -7,8 +7,11 @@ The [timelock example] demonstrates how to write a timelock and implements a
 greatly simplified claimable balance similar to the [claimable balance] feature
 available on Stellar.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.1.1
+
 The contract accepts deposits of an amount of a token, and allows other accounts
 to claim it before or after a time point.
 
-[timelock example]: https://github.com/stellar/soroban-examples/tree/v0.1.0/timelock
+[timelock example]: https://github.com/stellar/soroban-examples/tree/v0.1.1/timelock
 [claimable balance]: https://developers.stellar.org/docs/glossary/claimable-balance


### PR DESCRIPTION
### What
Add gitpod links.

### Why
So that gitpod is accessible.

Note that I needed to tag a new version of the soroban examples for this, and so the docs are also being updated in this change to reference that new version.