### PR TITLE
Remove recommendation to use the rlib crate type

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -36,7 +36,7 @@ Report issues and share feedback about the `soroban-sdk`
 
 ```toml
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/tutorials/create-a-project.mdx
+++ b/docs/tutorials/create-a-project.mdx
@@ -29,7 +29,7 @@ Add the `crate-type` configuration, required for building contracts.
 
 ```toml
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 ```
 
 ## Import `soroban-sdk` and Features
@@ -111,7 +111,7 @@ The steps below should produce a `Cargo.toml` that looks like so.
 
 ```toml title="Cargo.toml"
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]


### PR DESCRIPTION
### What
Remove recommendation to use the rlib crate type.

### Why
It bloats contracts and it isn't needed.

Related to https://github.com/stellar/soroban-examples/pull/163