### PR TITLE
Fix link to token contract CAP

### DIFF
--- a/docs/built-in-contracts/token.mdx
+++ b/docs/built-in-contracts/token.mdx
@@ -7,7 +7,7 @@ title: Token Contract
 
 The token contract is an implementation of [CAP-46-6 Smart Contract Standardized Asset].
 
-[CAP-46-6 Smart Contract Standardized Asset]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md
+[CAP-46-6 Smart Contract Standardized Asset]: https://stellar.org/protocol/cap-46-06
 
 :::caution
 The token contract is in early development, has not been audited, and is

--- a/docs/built-in-contracts/token.mdx
+++ b/docs/built-in-contracts/token.mdx
@@ -5,9 +5,9 @@ title: Token Contract
 
 # Token Contract
 
-The token contract is an implementation of [CAP-54 Smart Contract Standardized Asset].
+The token contract is an implementation of [CAP-46-6 Smart Contract Standardized Asset].
 
-[CAP-54 Smart Contract Standardized Asset]: https://stellar.org/protocol/cap-54
+[CAP-46-6 Smart Contract Standardized Asset]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md
 
 :::caution
 The token contract is in early development, has not been audited, and is


### PR DESCRIPTION
CAP-0054 was renamed to CAP-0046-06.

Related to this, the shorthand form of the links may not work with the new format. For example, we can link to CAP-0046 using https://stellar.org/protocol/cap-46, but I'm not sure how to link to CAP-0046-06. https://stellar.org/protocol/cap-46-6 doesn't work. @tyvdh or @leighmcculloch, do you know how and where this link forwarding is setup?