### PR TITLE
Add page with releases and changelogs

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -20,7 +20,7 @@ network passphrase changes.
 
 [FutureNet]: networks/futurenet
 
-## Preview Release 2 (November 15th, 2022)
+## Preview 2 (November 15th, 2022)
 
 ### Software
 
@@ -66,7 +66,7 @@ See https://github.com/stellar/rs-soroban-env/releases v0.0.7, v0.0.8, v0.0.9 fo
 
 See https://github.com/stellar/rs-soroban-sdk/releases v0.2.0, v0.2.1 for more details.
 
-## Preview Release 1 (October 11th, 2022)
+## Preview 1 (October 11th, 2022)
 
 ### Software
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -10,6 +10,16 @@ share the development process, and we want Stellar ecosystem developers and
 smart contract developers from other ecosystems to have a chance to experiment
 and provide feedback.
 
+:::warning
+Preview releases are software releases that are also released to the [FutureNet]
+test network. Software releases may occur between FutureNet releases. If you're
+interacting with FutureNet the recommended software versions to use in
+development are below. Releases to FutureNet may include network resets and
+network passphrase changes.
+:::
+
+[FutureNet]: networks/futurenet
+
 ## Preview Release 2 (November 15th, 2022)
 
 ### Software
@@ -24,6 +34,7 @@ and provide feedback.
 | Soroban RPC | ??? |
 | Stellar Horizon | `2.22.0~soroban-304` |
 | Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:0993d3350148af6ffeab5dc8f0b835236b28dade6dcae77ff8a09317162f768d` |
+| FutureNet Network Passphrase | `Test SDF Future Network ; October 2022` |
 
 ### Changelog
 
@@ -69,6 +80,7 @@ See https://github.com/stellar/rs-soroban-sdk/releases v0.2.0, v0.2.1 for more d
 | Soroban RPC | ??? |
 | Stellar Horizon | `2.22.0~soroban-304` |
 | Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:e58d83f92a61f43406087f488dd1cba110a92646dca85f14b3a416163609e853` |
+| FutureNet Network Passphrase | `Test SDF Future Network ; October 2022` |
 
 ### Changelog
 - Initial Preview Release

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,0 +1,47 @@
+---
+sidebar_position: 1
+title: Releases
+---
+
+The following Soroban releases are preview releases.
+
+We’re releasing early versions of Soroban because we believe it’s important to
+share the development process, and we want Stellar ecosystem developers and
+smart contract developers from other ecosystems to have a chance to experiment
+and provide feedback.
+
+## Preview Release 2 (November 15th, 2022)
+
+### Software
+
+| Software | Version |
+| -------- | ------- |
+| XDR | https://github.com/stellar/stellar-xdr-next/tree/48d5e17ae63bba0aa9725cd9d18d7438f44c07b1 |
+| Soroban Environment | `v0.0.9` |
+| Stellar Core | `19.5.1-1111.eba1d3de9.focal~soroban` |
+| Soroban Rust SDK | `v0.2.1` |
+| Soroban CLI | `v0.2.1` |
+| Soroban RPC | ??? |
+| Stellar Horizon | `2.22.0~soroban-304` |
+| Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:0993d3350148af6ffeab5dc8f0b835236b28dade6dcae77ff8a09317162f768d` |
+
+### Changelog
+- TODO
+
+## Preview Release 1 (October 11th, 2022)
+
+### Software
+
+| Software | Version |
+| -------- | ------- |
+| XDR | https://github.com/stellar/stellar-xdr-next/tree/161e2e5b64425a49f9ccfef7f732ae742ed5eec4 |
+| Soroban Environment | `v0.0.6` |
+| Stellar Core | `19.4.1-1097.4e813f20e.focal~soroban` |
+| Soroban Rust SDK | `v0.1.1` |
+| Soroban CLI | `v0.1.2` |
+| Soroban RPC | ??? |
+| Stellar Horizon | `2.22.0~soroban-304` |
+| Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:e58d83f92a61f43406087f488dd1cba110a92646dca85f14b3a416163609e853` |
+
+### Changelog
+- Initial Preview Release

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Releases
+title: Preview Releases
 ---
 
 The following Soroban releases are preview releases.

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -10,7 +10,7 @@ share the development process, and we want Stellar ecosystem developers and
 smart contract developers from other ecosystems to have a chance to experiment
 and provide feedback.
 
-:::warning
+:::caution
 Preview releases are software releases that are also released to the [FutureNet]
 test network. Software releases may occur between FutureNet releases. If you're
 interacting with FutureNet the recommended software versions to use in

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -66,6 +66,17 @@ See https://github.com/stellar/rs-soroban-env/releases v0.0.7, v0.0.8, v0.0.9 fo
 
 See https://github.com/stellar/rs-soroban-sdk/releases v0.2.0, v0.2.1 for more details.
 
+#### Soroban CLI
+
+* Strings and symbols are rendered as text in JSON output
+* Bytes are rendered as hex in JSON output
+* Accounts in invocations are created in sandbox
+* Add optimize sub-command that optimizes contracts
+* Fix the bin name in the completion command
+* Fix jsonrpc compliance issue
+
+See https://github.com/stellar/soroban-cli/releases v0.2.0, v0.2.1 for more details.
+
 ## Preview 1 (October 11th, 2022)
 
 ### Software

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -26,7 +26,34 @@ and provide feedback.
 | Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:0993d3350148af6ffeab5dc8f0b835236b28dade6dcae77ff8a09317162f768d` |
 
 ### Changelog
-- TODO
+
+#### XDR
+
+* Trivial whitespace changes
+
+#### Soroban Environment
+
+* Vm tuning
+* Add token events
+* Catch panics from native contracts in try_call
+* Improved built-in token error reporting
+* Add missing conversion from Status->ScStatus for the ContractError variant
+* Capture user panic-strings in native builds, avoid spurious NoContractRunning error
+* Few small fixes to error debug events
+
+See https://github.com/stellar/rs-soroban-env/releases v0.0.7, v0.0.8, v0.0.9 for more details.
+
+#### Soroban Rust SDK
+
+* Add Logger::print in testutils
+* Add conversion from Address to Identifier
+* Remove deprecated functions
+* Remove panic-catching and fix tests that use newly-working native try_call
+* Reintroduce an optimized aborting unwrap
+* Add assert_with_error! macro
+* Rename panic_error! to panic_with_error!
+
+See https://github.com/stellar/rs-soroban-sdk/releases v0.2.0, v0.2.1 for more details.
 
 ## Preview Release 1 (October 11th, 2022)
 


### PR DESCRIPTION
### What
Add page with releases and changelogs

### Why
So that we record a history of the preview releases and communicate about what is changing.