### PR TITLE
update links

### DIFF
--- a/docs/sdks/byo.mdx
+++ b/docs/sdks/byo.mdx
@@ -115,5 +115,5 @@ The test environment should include:
 [Vec]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/vec.rs
 [Bytes]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/bytes.rs
 [BigInt]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/bigint.rs
-[`SCEnvMetaEntry`]: https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-env-meta.x
-[`SCSpecEntry`]: https://github.com/stellar/rs-stellar-xdr/blob/main/xdr/next/Stellar-contract-spec.x
+[`SCEnvMetaEntry`]: https://github.com/stellar/stellar-xdr/blob/next/Stellar-contract-env-meta.x
+[`SCSpecEntry`]: https://github.com/stellar/stellar-xdr/blob/next/Stellar-contract-spec.x


### PR DESCRIPTION
update links to `SCEnvMetaEntry` and `SCSpecEntry` definitions.

rs-stellar-sdk now uses git submodules and the previous links are dead.