### PR TITLE
Rename and move releases page

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 1
-title: Preview Releases
+sidebar_position: 7
+title: Releases
 ---
 
 The following Soroban releases are preview releases.


### PR DESCRIPTION
### What
Rename and move releases page

### Why
We don't need preview in the name, and it doesn't need prominent placement.