### PR TITLE
Add js-stellar-base and js-soroban-client versions to release notes

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -35,6 +35,8 @@ network passphrase changes.
 | Stellar Horizon | `stellar-horizon:2.22.0~soroban-318` |
 | Stellar Friendbot | `soroban-v0.0.2-alpha` |
 | Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27` |
+| Stellar JS Stellar Base | `8.0.1-soroban.5` |
+| Stellar JS Soroban Client | `v0.2.0` |
 | Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
 
 ### Changelog


### PR DESCRIPTION
### What
Add js-stellar-base and js-soroban-client versions to release notes.

### Why
So that the versions are in the release notes.