### PR TITLE
Updating the futurenet and localnet tutorials with latest quickstart

### DIFF
--- a/docs/tutorials/deploy-to-futurenet.mdx
+++ b/docs/tutorials/deploy-to-futurenet.mdx
@@ -22,7 +22,7 @@ docker run --rm -it \
   --platform linux/amd64 \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev@sha256:0993d3350148af6ffeab5dc8f0b835236b28dade6dcae77ff8a09317162f768d \
+  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
   --futurenet \
   --enable-soroban-rpc
 ```

--- a/docs/tutorials/deploy-to-local-network.mdx
+++ b/docs/tutorials/deploy-to-local-network.mdx
@@ -29,7 +29,7 @@ docker run --rm -it \
   --platform linux/amd64 \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev@sha256:0993d3350148af6ffeab5dc8f0b835236b28dade6dcae77ff8a09317162f768d \
+  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
   --standalone \
   --enable-soroban-rpc
 ```


### PR DESCRIPTION
The previous image hash was used in these two tutorials, but is no longer working (I assume because there are no other nodes running that version).

Here, both tutorials are updated to the latest preview version of the quickstart image.