### PR TITLE
Update outdated token terminology

### DIFF
--- a/docs/built-in-contracts/stellar-asset-contract.mdx
+++ b/docs/built-in-contracts/stellar-asset-contract.mdx
@@ -10,7 +10,7 @@ The Stellar Asset Contract is an implementation of [CAP-46-6 Smart Contract Stan
 [CAP-46-6 Smart Contract Standardized Asset]: https://stellar.org/protocol/cap-46-06
 
 :::caution
-The token contract is in early development, has not been audited, and is
+The Stellar Asset Contract is in early development, has not been audited, and is
 intended for use in development and testing only at this stage. Report issues
 [here](https://github.com/stellar/soroban-token-contract/issues/new/choose).
 :::

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -17,12 +17,11 @@ A Soroban contract can be invoked by submitting a transaction that contains the 
 Yes. Stellar accounts are shared with Soroban. Smart contacts have access to Stellar account signer configuration and know the source account that directly invoked them in a transaction. Check out the Auth and Advanced Auth examples for more information.  
 
 ### Can Soroban contracts interact with Stellar Assets?
-Yes. Soroban contains a built-in token contract that is able to import a balance from a Stellar trust line into an equivalent Soroban balance and also to export it back to the Stellar trust line. Check out the built-in token for more information on token capabilities, and the token interface for building your own tokens with custom behaviors. 
-*Note 1: This means that one account can simultaneously have two balances of the same asset: once in a Stellar trust line and one in a Soroban token balance. This bears some similarity to the relationship between ETH and WETH on Ethereum.*   
-*Note 2: Tokens that have been issued on Soroban can not be exported to a Stellar trust line.*
+Yes. Soroban contains a built-in Stellar Asset Contract that is able to interact
+with classic trustlines. Read more about this [here](built-in-contracts/stellar-asset-contract.mdx).
 
-### Do Issuers of Stellar Assets maintain their authorization over an asset that has been imported to Soroban? (AUTH_REQUIRED, AUTH_REVOCABLE, AUTH_CLAWBACK)
-Yes. Issuers retain the same level of control on Soroban as they have on Classic . This functionality is accessible through a set of admin functions (freeze, burn) on the built in Soroban token contract.
+### Do Issuers of Stellar Assets maintain their authorization over an asset that has been sent to a non-account identifer in Soroban? (AUTH_REQUIRED, AUTH_REVOCABLE, AUTH_CLAWBACK)
+Yes. Issuers retain the same level of control on Soroban as they have on Classic. This functionality is accessible through a set of admin functions (clawback, set_auth) on the built-in Stellar Asset Contract.
 
 ### Can Soroban contracts interact with any other Stellar operations?
 No. Aside from the interactions with Accounts and Assets as mentioned above. This means that Soroban contracts can not interact with SDEX, AMMs, Claimable Balances or Sponsorships.  
@@ -30,11 +29,11 @@ No. Aside from the interactions with Accounts and Assets as mentioned above. Thi
 ### Does the Stellar base reserve apply to Soroban contracts?
 No. Soroban has a different fee structure and ledger entries that are allocated by Soroban contracts do not add to an account's required minimal balance.
 
-### Should I issue my token as a Stellar Asset or a Soroban token?
-We recommend, to the extent possible, issuing tokens as Stellar assets. These tokens will benefit from being interopable with the existing ecosystem of tools available in the Stellar ecosystem, and will be usable on Soroban through import/export functionality. 
-
-### How should Wallets handle Accounts having a Stellar and Soroban balance?
-Best practices are still being explored. At this time we recommend: (1) displaying separate balances for Soroban and Stellar Assets, (2) allowing users to import/export between them and (3) executing payments based on the origin: Stellar payments for trust lines and Soroban token transfers for Soroban token balances  
+### Should I issue my token as a Stellar Asset or a custom Soroban token?
+We recommend, to the extent possible, issuing tokens as Stellar assets. These
+tokens will benefit from being interopable with the existing ecosystem of tools
+available in the Stellar ecosystem, as well as being more performant because the
+Stellar Asset Contract is built into the host.
 
 ### Haven't found what you're looking for?
 Join #soroban on the Stellar developer discord

--- a/docs/tutorials/invoking-contracts-with-transactions.mdx
+++ b/docs/tutorials/invoking-contracts-with-transactions.mdx
@@ -11,7 +11,7 @@ operations:
 - Invoke contract functions.
 - Install WASM of the new contracts.
 - Deploy new contracts using the installed WASM or built-in implementations (
-  this currently includes only the [token contract](../built-in-contracts/token.mdx)).
+  this currently includes only the [token contract](../built-in-contracts/stellar-asset-contract.mdx)).
 
 [`soroban-cli`]: ../getting-started/setup#install-the-soroban-cli
 


### PR DESCRIPTION
This updates the rest of the docs to more accurately reflect how tokens works on Soroban.