### PR TITLE
Add token example to docs

### DIFF
--- a/docs/examples/token.mdx
+++ b/docs/examples/token.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_position: 15
+title: Token
+---
+
+The [token example] demonstrates how to write a token contract that implements the [common token interface].
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.4.2
+
+[common token interface]: ../common-interfaces/token.mdx
+[token example]: https://github.com/stellar/soroban-examples/tree/v0.4.2/token
+


### PR DESCRIPTION
Undo https://github.com/stellar/soroban-docs/pull/183 because we removed the soroban-only built-in token.