### PR TITLE
update setup instuctions

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -54,7 +54,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```sh
-cargo install --locked --version 0.3.3 soroban-cli
+cargo install --locked --version 0.4.0 soroban-cli
 ```
 
 :::info
@@ -72,7 +72,7 @@ soroban
 
 ```
 ❯ soroban
-soroban 0.3.3
+soroban 0.4.0
 https://soroban.stellar.org
 
 USAGE:

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -51,10 +51,10 @@ A popular editor is Visual Studio Code:
 The Soroban CLI can execute Soroban contracts in the same environment the
 contract will execute on network, however in a local sandbox.
 
-Install the Soroban CLI using `cargo install`.
+Install the latests Soroban CLI using `cargo install`.
 
 ```sh
-cargo install --locked --version 0.4.0 soroban-cli
+cargo install --locked soroban-cli
 ```
 
 :::info
@@ -96,6 +96,9 @@ SUBCOMMANDS:
     completion    Print shell completion code for the specified shell
 ```
 
+:::info
+The version and the sub commands above were generated using the soroban-cli 0.4.0. Future versions are expected to extend these.
+:::
 
 [Rust]: https://www.rust-lang.org/
 [Soroban CLI]: setup#install-the-soroban-cli

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -51,7 +51,7 @@ A popular editor is Visual Studio Code:
 The Soroban CLI can execute Soroban contracts in the same environment the
 contract will execute on network, however in a local sandbox.
 
-Install the latests Soroban CLI using `cargo install`.
+Install the latest Soroban CLI using `cargo install`.
 
 ```sh
 cargo install --locked soroban-cli


### PR DESCRIPTION
update setup instructions in order to make them version agnostic.

The goal of this task is to write the setup instructions in a way that won't force us to update these setup instructions with every release we make.