### PR TITLE
Support arm64 images in docs for quickstart

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -35,7 +35,8 @@ network passphrase changes.
 | Soroban RPC | `0.4.0-10` |
 | Stellar Horizon | `stellar-horizon:2.22.0~soroban-323` |
 | Stellar Friendbot | `soroban-v0.0.2-alpha` |
-| Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:8968d5c3344fe447941ebef12c5bede6f15ba29b63317a488c16c5d5842e4a71` |
+| Stellar Quickstart (amd64) | `stellar/quickstart:soroban-dev@sha256:c4429def497ed78ca99ae40c8e2522ec932081b4428df992900b5bc8d53bd642` |
+| Stellar Quickstart (arm64) | `stellar/quickstart:soroban-dev@sha256:37205510329845f5fe533bb7c4c182d8f35b3a3515f0a6729889067663e1ec97` |
 | Stellar JS Stellar Base | `8.0.1-soroban.6` |
 | Stellar JS Soroban Client | `v0.3.0` |
 | Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |

--- a/docs/tutorials/deploy-to-futurenet.mdx
+++ b/docs/tutorials/deploy-to-futurenet.mdx
@@ -19,10 +19,9 @@ Docker image, run the following command.
 
 ```sh
 docker run --rm -it \
-  --platform linux/amd64 \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
+  stellar/quickstart:soroban-dev \
   --futurenet \
   --enable-soroban-rpc
 ```

--- a/docs/tutorials/deploy-to-local-network.mdx
+++ b/docs/tutorials/deploy-to-local-network.mdx
@@ -26,10 +26,9 @@ run the following command.
 
 ```sh
 docker run --rm -it \
-  --platform linux/amd64 \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
+  stellar/quickstart:soroban-dev \
   --standalone \
   --enable-soroban-rpc
 ```


### PR DESCRIPTION
### What
Remove specifying platform amd64 for the quickstart image and remove the digest pinning.

### Why
So that people using different architectures get the image most appropriate for their architecture. So that Apple Silicon computers do not need to use emulation.