### PR TITLE
Update setup.mdx

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -21,14 +21,16 @@ command.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-And install the `wasm32-unknown-unknown` target.
+If you use Windows, or need an alternative method of installing Rust, check out:  
+https://www.rust-lang.org/tools/install
+
+## Install the target
+
+Install the `wasm32-unknown-unknown` target.
 
 ```sh
 rustup target add wasm32-unknown-unknown
 ```
-
-If you use Windows, or need an alternative method of installing Rust, check out:  
-https://www.rust-lang.org/tools/install
 
 ## Configure an Editor
 


### PR DESCRIPTION
I had one of my devs try the Windows install and when you look at the existing docs, it looks like installing the wasm target is just for macOS/Linux/Unix-like systems.  Moving it below the Windows section and making it it's own section might help.