### PR TITLE
Clarify encoding of hash in the api docs

### DIFF
--- a/api/methods/getLatestLedger.mdx
+++ b/api/methods/getLatestLedger.mdx
@@ -15,6 +15,6 @@ For finding out the current latest known ledger of this node. This is a subset o
 ## Returns
 
 - `<object>`
-  - `id`: `<hash>` - hash of the latest ledger
+  - `id`: `<hash>` - hash of the latest ledger as a hex-encoded string
   - `protocolVersion`: `<number>`
   - `sequence`: `<number>`

--- a/api/methods/getTransactionStatus.mdx
+++ b/api/methods/getTransactionStatus.mdx
@@ -13,7 +13,7 @@ Clients will poll this to tell when the transaction has been completed.
 
 ## Parameters
 
-- `<hash>` - transaction hash to query
+- `<hash>` - transaction hash to query, as a hex-encoded string
 
 ## Returns
 

--- a/api/methods/requestAirdrop.mdx
+++ b/api/methods/requestAirdrop.mdx
@@ -19,7 +19,7 @@ Maybe we could replace this with a 'friendbotUrl' field in `getNetwork` method?
 ## Returns
 
 - `<object>`
-  - `transactionId`: `<hash>` - Transaction id of the transfer.
+  - `transactionId`: `<hash>` - Transaction id of the transfer as a hex-encoded string.
 
 ## Errors
 


### PR DESCRIPTION
A user on discord pointed out that there are a few places we don't actually specify the hash encoding in the docs.