### PR TITLE
Duplication of "cargo test -p" in custom account docs

### DIFF
--- a/docs/how-to-guides/custom-account.mdx
+++ b/docs/how-to-guides/custom-account.mdx
@@ -45,7 +45,7 @@ Or, skip the development environment setup and open this example in [Gitpod][oig
 To run the tests for the example use `cargo test`.
 
 ```
-cargo test -p cargo test -p soroban-account-contract
+cargo test -p soroban-account-contract
 ```
 
 You should see the output:


### PR DESCRIPTION
The command to run the tests has a duplication of cargo test -p