### PR TITLE
Clean up page descriptions in category indexes

### DIFF
--- a/api/anti-goals.mdx
+++ b/api/anti-goals.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Anti-Goals
+description: What Soroban-RPC is not.
 ---
 
 - Soroban-RPC is not a Horizon replacement. Horizon is better suited for historical reporting and analytics queries. Horizon is more concerned with Stellar Vanilla data.

--- a/api/goals.mdx
+++ b/api/goals.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 0
 title: Goals
+description: Features Soroban-RPC should provide.
 ---
 
 Soroban-RPC can be simply described as a "live network gateway for Soroban." It provides information that the network currently has in its view (i.e. current state). It also has the ability to send a transaction to the network, and query the network for the status of previously sent transactions. It is meant to be simple, minimal, scalable, and familiar to blockchain developers from other ecosystems.

--- a/api/json-rpc.mdx
+++ b/api/json-rpc.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: JSON-RPC
+description: Design goals for Soroban-RPC's JSON-RPC spec.
 ---
 
 Soroban-RPC will accept HTTP POST requests using the [JSON-RPC 2.0] specification. Errors are returned via the [jsonrpc error object] wherever possible (and makes sense).

--- a/api/methods/getEvents.mdx
+++ b/api/methods/getEvents.mdx
@@ -2,7 +2,9 @@
 sidebar_position: 6
 ---
 
-Clients can request a filtered list of events emitted by a given ledger range. Soroban-RPC will support querying within a maximum 24 hours of recent ledgers.
+Clients can request a filtered list of events emitted by a given ledger range.
+
+Soroban-RPC will support querying within a maximum 24 hours of recent ledgers.
 
 Note, this could be used by the client to only prompt a refresh when there is a new ledger with relevant events. It should also be used by backend Dapp components to "ingest" events into their own database for querying and serving.
 

--- a/api/methods/getLedgerEntry.mdx
+++ b/api/methods/getLedgerEntry.mdx
@@ -2,7 +2,9 @@
 sidebar_position: 4
 ---
 
-For reading the current value of ledger entries directly. Allows you to directly inspect the _current state_ of a contract, a contract's code, or any other ledger entry. This is a backup way to access your contract data which may not be available via events or `simulateTransaction`.
+For reading the current value of ledger entries directly.
+
+Allows you to directly inspect the _current state_ of a contract, a contract's code, or any other ledger entry. This is a backup way to access your contract data which may not be available via events or `simulateTransaction`.
 
 To fetch contract wasm byte-code, use the ContractCode ledger entry key.
 

--- a/api/pagination.mdx
+++ b/api/pagination.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Pagination
+description: Pagination in Soroban-RPC is similar to in Horizon.
 ---
 
 Pagination in soroban-rpc is similar to pagination in Horizon.

--- a/docs/getting-started/connect-freighter-wallet.mdx
+++ b/docs/getting-started/connect-freighter-wallet.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: 4. Connect Freighter Wallet
+description: Freighter is a browser extension that can sign Soroban transactions.
 ---
 
 ## Signing Transactions with Freighter

--- a/docs/getting-started/deploy-to-a-local-network.mdx
+++ b/docs/getting-started/deploy-to-a-local-network.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: 3. Deploy to a Local Network
+description: Use Docker and the Stellar Quickstart image to run a local network.
 ---
 
 If you have Docker installed, you can run a local standalone network with the [Stellar Quickstart] Docker image.

--- a/docs/getting-started/deploy-to-futurenet.mdx
+++ b/docs/getting-started/deploy-to-futurenet.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: 5. Deploy to Futurenet
+description: Use Docker and the Stellar Quickstart image to deploy to the live test network.
 ---
 
 If you have Docker installed, you can run a local node with the [Stellar Quickstart] Docker image that joins the [Futurenet] network, and then use that local node to deploy.

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 title: 1. Hello World
-description: Compile your first Soroban contract.
+description: Create your first Soroban contract.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: 1. Hello World
+description: Compile your first Soroban contract.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Setup
+description: Install and configure Rust and the Soroban CLI.
 ---
 
 Soroban contracts are small programs written in the [Rust] programming language.

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: 2. Storing Data
+description: Write a simple Soroban contract that stores and retrieves data.
 ---
 
 The [increment example] demonstrates how to write a simple contract that stores data, with a single function that increments an internal counter and returns the value.

--- a/docs/how-to-guides/alloc.mdx
+++ b/docs/how-to-guides/alloc.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 10
 title: Allocator
+description: Using the allocator feature of the SDK.
 ---
 
 The [allocator example] demonstrates how to utilize the allocator feature when writing a contract.

--- a/docs/how-to-guides/atomic-multi-swap.mdx
+++ b/docs/how-to-guides/atomic-multi-swap.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Batched Atomic Swaps
+description: Swapping tokens between two groups of users.
 ---
 
 The [atomic swap batching example] swaps a pair of tokens between the two groups

--- a/docs/how-to-guides/atomic-swap.mdx
+++ b/docs/how-to-guides/atomic-swap.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 11
 title: Atomic Swap
+description: Swapping tokens and using the auth framework.
 ---
 
 The [atomic swap example] swaps two tokens between two authorized parties 

--- a/docs/how-to-guides/auth-migration.mdx
+++ b/docs/how-to-guides/auth-migration.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 20
 title: Migrating Auth to SDK 0.6.0
+description: Migrating auth code for contracts written prior to SDK 0.6.0.
 ---
 
 This is a guide about migrating authorization code in contracts written before

--- a/docs/how-to-guides/auth.mdx
+++ b/docs/how-to-guides/auth.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: Auth
+description: Using the Soroban Host-managed auth framework.
 ---
 
 The [auth example] demonstrates how to implement authentication and

--- a/docs/how-to-guides/build-your-own-sdk.mdx
+++ b/docs/how-to-guides/build-your-own-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 21
 title: Build Your Own SDK
-description: A guide to developing Soroban SDK's for languages other than Rust.
+description: A guide to developing Soroban SDKs for languages other than Rust.
 ---
 
 Soroban currently has one SDK for writing contracts in Rust, which can be found [here][soroban-sdk].

--- a/docs/how-to-guides/build-your-own-sdk.mdx
+++ b/docs/how-to-guides/build-your-own-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 21
 title: Build Your Own SDK
+description: A guide to developing Soroban SDK's for languages other than Rust.
 ---
 
 Soroban currently has one SDK for writing contracts in Rust, which can be found [here][soroban-sdk].

--- a/docs/how-to-guides/cross-contract-call.mdx
+++ b/docs/how-to-guides/cross-contract-call.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 title: Cross Contract Calls
+description: Calling a contract from another contract.
 ---
 
 The [cross contract call example] demonstrates how to call a contract from

--- a/docs/how-to-guides/custom-account.mdx
+++ b/docs/how-to-guides/custom-account.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 18
 title: Custom Account
+description: Accounts that support multisig and custom auth policies.
 ---
 
 The [custom account example] demonstrates how to implement a simple account

--- a/docs/how-to-guides/custom-types.mdx
+++ b/docs/how-to-guides/custom-types.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Custom Types
+description: Defining data structures that can be stored on the ledger.
 ---
 
 The [custom types example] demonstrates how to define your own data structures that can be stored on the ledger, or used as inputs and outputs to contract invocations. This example is an extension of the [storing data example].

--- a/docs/how-to-guides/deployer.mdx
+++ b/docs/how-to-guides/deployer.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 9
 title: Deployer
+description: Deploying a contract from another contract.
 ---
 
 The [deployer example] demonstrates how to deploy contracts using a contract.

--- a/docs/how-to-guides/errors.mdx
+++ b/docs/how-to-guides/errors.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Errors
+description: Defining errors that invokers can handle.
 ---
 
 The [errors example] demonstrates how to define and generate errors in a

--- a/docs/how-to-guides/events.mdx
+++ b/docs/how-to-guides/events.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Events
+description: Publishing events from a contract.
 ---
 
 The [events example] demonstrates how to publish events from a contract. This

--- a/docs/how-to-guides/invoking-contracts-with-transactions.mdx
+++ b/docs/how-to-guides/invoking-contracts-with-transactions.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 19
 title: Invoking and Creating Contracts with Stellar Transactions
+description: A description of the InvokeHostFunctionOp operation.
 ---
 
 Stellar supports invoking and deploying contracts with a new Operation named `InvokeHostFunctionOp`. The [`soroban-cli`] abstracts these details away from the user, but SDKs do not yet and if you're building a dapp you'll probably find yourself building the XDR transaction to submit to the network.

--- a/docs/how-to-guides/liquidity-pool.mdx
+++ b/docs/how-to-guides/liquidity-pool.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 15
 title: Liquidity Pool
+description: A constant-product liquidity pool contract.
 ---
 
 The [liquidity pool example] demonstrates how to write a constant product liquidity pool contract. The comments in the [source code] explain how the contract should be used.

--- a/docs/how-to-guides/logging.mdx
+++ b/docs/how-to-guides/logging.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: Logging
+description: How to log for the purpose of debugging.
 ---
 
 The [logging example] demonstrates how to log for the purpose of debugging.

--- a/docs/how-to-guides/single-offer-sale.mdx
+++ b/docs/how-to-guides/single-offer-sale.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 14
 title: Single Offer Sale
+description: Selling token A for token B to multiple buyers.
 ---
 
 The [single offer sale example] demonstrates how to write a contract that allows

--- a/docs/how-to-guides/stellar-asset-contract.mdx
+++ b/docs/how-to-guides/stellar-asset-contract.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 17
 title: Stellar Asset Contract
+description: An implementation of CAP-46-6 smart contract standardized assets.
 ---
 
 # Stellar Asset Contract

--- a/docs/how-to-guides/timelock.mdx
+++ b/docs/how-to-guides/timelock.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 13
 title: Timelock
+description: Writing a timelock that implements a simple claimable balance.
 ---
 
 The [timelock example] demonstrates how to write a timelock and implements a

--- a/docs/how-to-guides/tokens.mdx
+++ b/docs/how-to-guides/tokens.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 16
 title: Tokens
+description: A token contract that implements the standard token interface.
 ---
 
 ## Token Example

--- a/docs/learn/authorization.mdx
+++ b/docs/learn/authorization.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Authorization
+description: An overview of the Soroban authorization framework.
 ---
 
 :::info

--- a/docs/learn/built-in-types.mdx
+++ b/docs/learn/built-in-types.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Built-In Types
+description: A description of built-in types used as contract inputs and outputs.
 ---
 
 Built-in types are available to all contracts for use as contract function

--- a/docs/learn/contract-lifecycle.mdx
+++ b/docs/learn/contract-lifecycle.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Contract Lifecycle
+description: The workflow of developing, deploying and maintaining Soroban contracts.
 ---
 
 ## Development

--- a/docs/learn/contract-lifecycle.mdx
+++ b/docs/learn/contract-lifecycle.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: Contract Lifecycle
-description: The workflow of developing, deploying and maintaining Soroban contracts.
+description: The workflow of developing, deploying, and maintaining Soroban contracts.
 ---
 
 ## Development

--- a/docs/learn/custom-types.mdx
+++ b/docs/learn/custom-types.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Custom Types
+description: Struct, union, and enum types defined by contracts.
 ---
 
 Custom types are struct, union, and enum types defined by contracts. They are

--- a/docs/learn/debugging.mdx
+++ b/docs/learn/debugging.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: Debugging
+description: How to debug Soroban contracts natively and as WASM.
 ---
 
 Soroban contracts are as much as possible regular Rust programs and can be debugged using the same tools you'd usually use.

--- a/docs/learn/environment-concepts.mdx
+++ b/docs/learn/environment-concepts.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 title: Environment Concepts
+description: The interface that defines objects, functions and data available to contracts.
 ---
 
 The contract environment is an _interface_ that defines the facilities -- objects, functions, data sources, etc. -- available to contracts.

--- a/docs/learn/environment-concepts.mdx
+++ b/docs/learn/environment-concepts.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 title: Environment Concepts
-description: The interface that defines objects, functions and data available to contracts.
+description: The interface that defines objects, functions, and data available to contracts.
 ---
 
 The contract environment is an _interface_ that defines the facilities -- objects, functions, data sources, etc. -- available to contracts.

--- a/docs/learn/errors.mdx
+++ b/docs/learn/errors.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 9
 title: Errors
+description: Generating errors from contracts.
 ---
 
 There are a number of ways to generate errors in contracts.

--- a/docs/learn/events.mdx
+++ b/docs/learn/events.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 10
 title: Events
+description: The mechanism that off-chain applications use to monitor contract changes.
 ---
 
 Events are the mechanism that applications off-chain can use to monitor changes and events in contracts on-chain.

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: Soroban on Stellar FAQs
+description: Frequently asked questions about Soroban on Stellar.
 ---
 
 :::caution

--- a/docs/learn/gas-and-metering.mdx
+++ b/docs/learn/gas-and-metering.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 11
 title: Gas and Metering
+description: The mechanisms that will measure and bill the cost of running a contract.
 ---
 
 Gas and metering are the mechanisms that will measure the cost of running a contract and bill that cost to the account executing the contract.

--- a/docs/learn/high-level-overview.mdx
+++ b/docs/learn/high-level-overview.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: High-Level Overview
+description: Descriptions of key Soroban concepts.
 ---
 
 ## Rust language

--- a/docs/learn/interacting-with-contracts.mdx
+++ b/docs/learn/interacting-with-contracts.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Interacting with Contracts
+description: Function calls, contract invocation, Stellar ops, and testing.
 ---
 
 ## Three types of interactions

--- a/docs/learn/persisting-data.mdx
+++ b/docs/learn/persisting-data.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Persisting Data
+description: Storing and accessing contract data.
 ---
 
 ## Ledger entries

--- a/docs/learn/rust-dialect.mdx
+++ b/docs/learn/rust-dialect.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: Contract Rust dialect
+description: Differences between Soroban Rust and typical Rust programming.
 ---
 
 Contract development occurs in the Rust programming language, but several features of the Rust language are either unavailable in the deployment guest environment, or not recommended because their use would incur unacceptable costs at runtime.

--- a/docs/learn/rust-dialect.mdx
+++ b/docs/learn/rust-dialect.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-title: Contract Rust dialect
+title: Contract Rust Dialect
 description: Differences between Soroban Rust and typical Rust programming.
 ---
 

--- a/docs/reference/command-line.mdx
+++ b/docs/reference/command-line.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: soroban-cli
+description: The tool for interacting with deployed contracts.
 ---
 
 `soroban-cli` allows you to interact with deployed contracts, set different identities to sign with, set different networks, and generate new keys.

--- a/docs/reference/futurenet.mdx
+++ b/docs/reference/futurenet.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Futurenet
+description: The shared Soroban test network.
 ---
 
 Futurenet is available as the first shared test network to enable developers to learn, tinker and build applications on Soroban while being able to interact with other participants.

--- a/docs/reference/interfaces/_category_.json
+++ b/docs/reference/interfaces/_category_.json
@@ -1,4 +1,7 @@
 {
     "position": 2,
-    "label": "Interfaces"
-  }
+    "label": "Interfaces",
+    "link": {
+        "type": "generated-index"
+    }
+}

--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Token Interface
+description: The common interface implemented by tokens that are compatible with Soroban's built-in tokens.
 ---
 
 Token contracts, including the Stellar Asset Contract and example token

--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Releases
+description: Soroban software releases and changelogs.
 ---
 
 The following Soroban releases are preview releases.

--- a/docs/reference/sdks/_category_.json
+++ b/docs/reference/sdks/_category_.json
@@ -1,4 +1,7 @@
 {
     "position": 1,
-    "label": "SDKs"
-  }
+    "label": "SDKs",
+    "link": {
+        "type": "generated-index"
+    }
+}

--- a/docs/reference/sdks/assemblyscript-sdk.mdx
+++ b/docs/reference/sdks/assemblyscript-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Soroban AssemblyScript SDK
+description: as-soroban-sdk supports writing Soroban contracts in AssemblyScript.
 ---
 
 The `as-soroban-sdk` is an open source SDK that supports writing programs for the Soroban smart contract platform by using the AssemblyScript programming language.

--- a/docs/reference/sdks/flutter-sdk.mdx
+++ b/docs/reference/sdks/flutter-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: Flutter SDK
+description: stellar-flutter-sdk supports writing Soroban applications in Flutter.
 ---
 
 The `stellar-flutter-sdk` is an open source Stellar SDK for Flutter developers. It provides APIs to build transactions and connect to Horizon. 

--- a/docs/reference/sdks/ios-sdk.mdx
+++ b/docs/reference/sdks/ios-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: iOS SDK
+description: stellar-ios-mac-sdk supports writing Soroban applications for iOS and Mac.
 ---
 
 The `stellar-ios-mac-sdk` is an open source Stellar SDK for iOS & Mac. It provides APIs to build transactions and connect to Horizon. 

--- a/docs/reference/sdks/js.mdx
+++ b/docs/reference/sdks/js.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: JavaScript SDK
+description: js-soroban-client supports writing Soroban applications in JavaScript.
 ---
 
 js-soroban-client is a Javascript library for communicating with a Soroban RPC server. It is used for building Stellar apps either on Node.js or in the browser.

--- a/docs/reference/sdks/php-sdk.mdx
+++ b/docs/reference/sdks/php-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 title: PHP SDK
+description: stellar-php-sdk supports writing Soroban applications in PHP.
 ---
 
 The `stellar-php-sdk` is an open source Stellar SDK for PHP developers. It provides APIs to build transactions and connect to Horizon. 

--- a/docs/reference/sdks/python.mdx
+++ b/docs/reference/sdks/python.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Python SDK
+description: py-stellar-base supports writing Soroban applications in Python.
 ---
 
 py-stellar-base is a Python library for communicating with a Stellar Horizon server. It is used for building Stellar apps on Python. It supports Python 3.7+ as well as PyPy 3.7+.

--- a/docs/reference/sdks/rust.mdx
+++ b/docs/reference/sdks/rust.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Soroban Rust SDK
+description: soroban-sdk supports writing Soroban contracts in Rust.
 ---
 
 The `soroban-sdk` Rust crate contains the Soroban Rust SDK.


### PR DESCRIPTION
The docs include several generated category index pages:

- https://soroban.stellar.org/docs/category/getting-started
- https://soroban.stellar.org/docs/category/how-to-guides
- https://soroban.stellar.org/docs/category/learn
- https://soroban.stellar.org/docs/category/reference
- https://soroban.stellar.org/api
- https://soroban.stellar.org/api/methods
- https://soroban.stellar.org/api/incomplete-methods

The descriptions of subpages on these pages are taken from the first text line of their respective links, and are not presented in a consistent way: they have broken markdown link syntax (`[foo]`) and incomplete sentences, among other things. This can be seen particularly in the mobile layout where each page's description spans the full page width.

It makes a poor first impression for readers.

This patch uses the `description` frontmatter to present short descriptions appropriate for each page.

It additionally turns on category indexes for the "docs/reference/sdks" and docs/reference/interfaces" directories: currently these subdirectories to not have index pages, making the navigation experience surprisingly inconsestent.

Fixes https://github.com/stellar/soroban-docs/issues/347