### PR TITLE
feat: use 0.7 syntax with `invoke` commands

### DIFF
--- a/docs/getting-started/deploy-to-a-local-network.mdx
+++ b/docs/getting-started/deploy-to-a-local-network.mdx
@@ -79,8 +79,8 @@ soroban contract invoke \
     --secret-key S... \
     --rpc-url http://localhost:8000/soroban/rpc \
     --network-passphrase 'Standalone Network ; February 2017' \
-    --fn hello \
     -- \
+    hello \
     --to friend
 ```
 

--- a/docs/getting-started/deploy-to-futurenet.mdx
+++ b/docs/getting-started/deploy-to-futurenet.mdx
@@ -76,8 +76,8 @@ soroban contract invoke \
     --secret-key S... \
     --rpc-url http://localhost:8000/soroban/rpc \
     --network-passphrase 'Test SDF Future Network ; October 2022' \
-    --fn hello \
     -- \
+    hello \
     --to friend
 ```
 

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -349,7 +349,7 @@ The following output should appear.
 
 This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean) used by other commands like [cargo run](https://doc.rust-lang.org/cargo/commands/cargo-run.html). Everything after the `--`, sometimes called [slop](https://github.com/clap-rs/clap/issues/971), is passed to a child process. In this case, `soroban contract invoke` builds an _implicit CLI_ on-the-fly for the `hello` method in your contract. It can do this because Soroban SDK embeds your contract's schema / interface types right in the `.wasm` file that gets deployed on-chain. Try this, too:
 
-    soroban contract invoke ... -- --help
+    soroban contract invoke ... -- hello --help
 
 :::
 

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -334,8 +334,8 @@ Using the code we wrote in [Write a Contract] and the resulting `.wasm` file we 
 soroban contract invoke \
     --wasm target/wasm32-unknown-unknown/release/[project-name].wasm \
     --id 1 \
-    --fn hello \
     -- \
+    hello \
     --to friend
 ```
 
@@ -349,7 +349,7 @@ The following output should appear.
 
 This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean) used by other commands like [cargo run](https://doc.rust-lang.org/cargo/commands/cargo-run.html). Everything after the `--`, sometimes called [slop](https://github.com/clap-rs/clap/issues/971), is passed to a child process. In this case, `soroban contract invoke` builds an _implicit CLI_ on-the-fly for the `hello` method in your contract. It can do this because Soroban SDK embeds your contract's schema / interface types right in the `.wasm` file that gets deployed on-chain. Try this, too:
 
-    soroban contract invoke ... --fn hello -- --help
+    soroban contract invoke ... -- --help
 
 :::
 

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -165,7 +165,7 @@ If you have [`soroban-cli`] installed, you can invoke contract functions in the 
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
     --id 1 \
-    --fn increment
+    -- increment
 ```
 
 The following output should occur using the code above.
@@ -180,7 +180,7 @@ Rerun the invoke with the `--footprint` option to view the [footprint] of the in
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
     --id 1 \
-    --fn increment \
+    -- increment \
     --footprint
 ```
 

--- a/docs/how-to-guides/auth.mdx
+++ b/docs/how-to-guides/auth.mdx
@@ -312,7 +312,7 @@ soroban invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     --account GDQHNBKFCO666SPX4RS62VTDY7H5W2QXHVVVQCDTADTOI3IYZGEOZL6V \
-    --fn increment
+    -- increment
 ```
 
 ```sh
@@ -320,7 +320,7 @@ soroban invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     --account GC24I42QMKKR4NE6IYNPCQHUO4PXWXDGNZ7QVMMSR5EWAYSGKBHPLGHH \
-    --fn increment
+    -- increment
 ```
 
 Run these commands several times to increment the counters for each address.

--- a/docs/how-to-guides/cross-contract-call.mdx
+++ b/docs/how-to-guides/cross-contract-call.mdx
@@ -270,8 +270,8 @@ Invoke Contract B's `add_with` function, passing in values for `x` and `y`
 ```sh
 soroban contract invoke \
     --id b \
-    --fn add_with \
     -- \
+    add_with \
     --contract_id a \
     --x 5 \
     --y 7

--- a/docs/how-to-guides/custom-types.mdx
+++ b/docs/how-to-guides/custom-types.mdx
@@ -227,8 +227,8 @@ If you have [`soroban-cli`] installed, you can invoke contract functions in the 
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm \
     --id 1 \
-    --fn increment \
     -- \
+    increment \
     --incr 5
 ```
 

--- a/docs/how-to-guides/deployer.mdx
+++ b/docs/how-to-guides/deployer.mdx
@@ -295,8 +295,8 @@ Then the deployer contract may be invoked with the WASM hash value above.
 soroban contract invoke \
     --wasm target/wasm32-unknown-unknown/release/soroban_deployer_contract.wasm \
     --id 0 \
-    --fn deploy \
     -- \
+    deploy \
     --salt 0000000000000000000000000000000000000000000000000000000000000000 \
     --wasm_hash edce149b183ea03dfd896a263d2e17c1f08229da52afa6f822d9cbc67c103806 \
     --init_fn init \
@@ -309,7 +309,7 @@ the previous command.
 ```sh
 soroban contract invoke \
     --id ead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d \
-    --fn value
+    -- value
 ```
 
 The following output should occur using the code above.

--- a/docs/how-to-guides/errors.mdx
+++ b/docs/how-to-guides/errors.mdx
@@ -311,7 +311,7 @@ WASM using it.
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm \
     --id 1 \
-    --fn increment
+    -- increment
 ```
 
 Run the command a few times and on the 6th invocation the following output should occur.
@@ -320,7 +320,7 @@ Run the command a few times and on the 6th invocation the following output shoul
 ❯ soroban contract invoke \
     --wasm target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm \
     --id 1 \
-    --fn increment
+    -- increment
 error: HostError
 Value: Status(ContractError(1))
 ...

--- a/docs/how-to-guides/events.mdx
+++ b/docs/how-to-guides/events.mdx
@@ -233,7 +233,7 @@ using it.
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_events_contract.wasm \
     --id 1 \
-    --fn increment
+    -- increment
 ```
 
 The following output should occur using the code above.

--- a/docs/how-to-guides/hello-world.mdx
+++ b/docs/how-to-guides/hello-world.mdx
@@ -150,8 +150,8 @@ If you have [`soroban-cli`] installed, you can invoke contract functions in the 
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm \
     --id 1 \
-    --fn hello \
     -- \
+    hello \
     --to friend
 ```
 

--- a/docs/how-to-guides/logging.mdx
+++ b/docs/how-to-guides/logging.mdx
@@ -264,8 +264,8 @@ using it.
 soroban contract invoke \
     --wasm ../target/wasm32-unknown-unknown/release-with-logs/soroban_logging_contract.wasm \
     --id 1 \
-    --fn hello \
     -- \
+    hello \
     --to friend
 ```
 

--- a/docs/reference/command-line.mdx
+++ b/docs/reference/command-line.mdx
@@ -28,7 +28,7 @@ alice
 Now this identity can be referenced when using other commands.  For example,
 
 ```bash
-soroban contract invoke --id 10 --identity alice --fn hello -- ..
+soroban contract invoke --id 10 --identity alice -- hello ..
 ```
 
 # The `contract` subcommand
@@ -66,7 +66,7 @@ Since each contract has its xdr definition embedded in the binary, it's possible
 Anything after the `--` is parsed as arguments to the function. And it even includes a help page
 
 ```bash
-soroban contract invoke --id 10 --identity alice --fn hello -- --help
+soroban contract invoke --id 10 --identity alice -- --help
 ```
 
 ## Arguments as flags
@@ -74,7 +74,7 @@ soroban contract invoke --id 10 --identity alice --fn hello -- --help
 Each argument to the contract function is parsed as flags. For example,
 
 ```bash
-soroban contract invoke --id 10 --identity alice --fn hello -- --to world
+soroban contract invoke --id 10 --identity alice -- hello --to world
 ```
 
 Would pass `world` to the `hello` function.


### PR DESCRIPTION
In soroban-cli v0.7.0, the function-to-call behaves as a subcommand within after the `--` double-dash to `invoke`