### PR TITLE
Update getEvents documentation to include event type csv and inSuccessfulContractCall field

### DIFF
--- a/api/methods/getEvents.mdx
+++ b/api/methods/getEvents.mdx
@@ -16,7 +16,7 @@ By default soroban-rpc retains the most recent 24 hours of events.
 
 - `startLedger`: `<string>` - Stringified ledger sequence number to fetch events after (inclusive). This method will return an error if `startLedger` is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a [cursor](../pagination) is included in the request, `startLedger` must be omitted.
 - `filters`: `<object[]>` - List of filters for the returned events. Events matching any of the filters are included. To match a filter, an event must match both a contractId and a topic. Maximum 5 filters are allowed per request.
-  - `type`: `<"system"|"contract"|"diagnostic">` - (optional) Filter to only system, diagnostic, or only contract type events. If omitted, return all.
+  - `type`: `<string>` - (optional) A comma separated list of event types (`system`, `contract`, or `diagnostic`) used to filter events. If omitted, all event types are included.
   - `contractIds`: `<string[]>` - (optional) List of contract ids to query for events. If omitted, return events for all contracts. Maximum 5 contract IDs are allowed per request.
   - `topics`: `<TopicFilter[]>` - (optional) List of topic filters. If omitted, query for all events. If multiple filters are specified, events will be included if they match any of the filters. Maximum 5 filters are allowed per request.
     - A `TopicFilter` is `SegmentMatcher[]`
@@ -49,6 +49,7 @@ By default soroban-rpc retains the most recent 24 hours of events.
       - For example:
         - 1234-1
     - `pagingToken`: `<string>` - Duplicate of `id` field, but in the standard place for pagination tokens.
+    - `inSuccessfulContractCall`: `<boolean>` - If true the event was emitted during a successful contract call.
     - `topic`: `<xdr.ScVal[]>` - List containing the topic this event was emitted with.
     - `value`: `<object>` - List containing the topic this event was emitted with.
       - `xdr`: `<xdr.ScVal>` - The emitted body value of the event (serialized in a base64 string).
@@ -106,6 +107,7 @@ The examples below only returns two transfer events that took place to/from the 
         "contractId": "d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813",
         "id": "0000987885427757056-0000000001",
         "pagingToken": "0000987885427757056-0000000001",
+        "inSuccessfulContractCall": true,
         "topic": [
           "AAAABQAAAAh0cmFuc2Zlcg==",
           "AAAABAAAAAEAAAAAAAAAAgAAAAUAAAAHQWNjb3VudAAAAAAEAAAAAQAAAAgAAAAAHavpBsZgRv4pEDXWB0NnwQBvvAL/8adWXz2fV7eNq2o=",
@@ -122,6 +124,7 @@ The examples below only returns two transfer events that took place to/from the 
         "contractId": "d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813",
         "id": "0000988572622524416-0000000001",
         "pagingToken": "0000988572622524416-0000000001",
+        "inSuccessfulContractCall": true,
         "topic": [
           "AAAABQAAAAh0cmFuc2Zlcg==",
           "AAAABAAAAAEAAAAAAAAAAgAAAAUAAAAHQWNjb3VudAAAAAAEAAAAAQAAAAgAAAAAHavpBsZgRv4pEDXWB0NnwQBvvAL/8adWXz2fV7eNq2o=",


### PR DESCRIPTION
This commit updates the getEvents documentation to match the implementation changes in https://github.com/stellar/soroban-tools/pull/536