### PR TITLE
Correction to the soroban CLI command

### DIFF
--- a/docs/how-to-guides/logging.mdx
+++ b/docs/how-to-guides/logging.mdx
@@ -267,7 +267,7 @@ soroban contract invoke \
     --id 1 \
     --fn hello \
     -- \
-    --to friend
+    --value friend
 ```
 
 The following output should occur using the code above.


### PR DESCRIPTION
To run the sample contract the soroban has an error in the last line `--to friend` if you try using this command the code will not run. Instead you need to use `--value friend`