### PR TITLE
Fix quickstart versions to include arm64

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -31,7 +31,8 @@ Preview releases are software releases that are also released to the [Futurenet]
 | Soroban RPC                  | `v0.7.0`                                                                                                                          |
 | Stellar Horizon              | `stellar-horizon:2.24.62~soroban-338`                                                                                                 |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                            |
-| Stellar Quickstart           | `stellar/quickstart:soroban-dev@sha256:3d14a36df8e7d3da899369f00231125d81745ab457076082d22eabc35c6de78e`                          |
+| Stellar Quickstart (amd64)   | `stellar/quickstart:soroban-dev@sha256:3d14a36df8e7d3da899369f00231125d81745ab457076082d22eabc35c6de78e`                          |
+| Stellar Quickstart (arm64)   | `stellar/quickstart:soroban-dev@sha256:6e0c2713f020735bfa20dac7e29cd110a167d120e2881abb5e7df9ed16654b49`                          |
 | Stellar JS Stellar Base      | `8.2.2-soroban.12`                                                                                                                |
 | Stellar JS Soroban Client    | `v0.5.0`                                                                                                                          |
 | Freighter                    |                                                                                                                          |


### PR DESCRIPTION
### What
Add the arm64 version of quickstart alongside the amd64.

### Why
There are two images that get published, and they have separate digests. Two previews ago we started listing both, then it appears we stopped doing it for some reason. This change backfills the missing digests.