### PR TITLE
Make Preview 8 Quickstart Sha256 the Multiplatform Manifest

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -31,7 +31,7 @@ Preview releases are software releases that are also released to the [Futurenet]
 | Soroban RPC                  | `v0.7.0`                                                                                                                          |
 | Stellar Horizon              | `stellar-horizon:2.24.62~soroban-338`                                                                                             |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                            |
-| Stellar Quickstart           | `stellar/quickstart:soroban-dev@sha256:3d14a36df8e7d3da899369f00231125d81745ab457076082d22eabc35c6de78e`                          |
+| Stellar Quickstart           | `stellar/quickstart:soroban-dev@sha256:a057ec6f06c6702c005693f8265ed1261e901b153a754e97cf18b0962257e872`                          |
 | Stellar JS Stellar Base      | `8.2.2-soroban.12`                                                                                                                |
 | Stellar JS Soroban Client    | `v0.5.0`                                                                                                                          |
 | Freighter                    |                                                                                                                                   |


### PR DESCRIPTION
### What
Change the sha256 digest hash for the quickstart image in preview 8 to be the digest of the multiplatform manifest instead of the amd64 digest.

### Why
We can reference the multiplatform manifest which will cause clients to pick the right platform. We don't need to specify the amd64 or arm64 manifest specifically.

Previously we listed the digests for amd64/arm64 separately. Or in some releases we only listed the amd64 digest.

Listing the multiplatform digest is more convenient. Folks don't need to know whether they are amd64 or arm64. Docker clients should just pick the right one automatically.

This gives us a single version to reference the release of both images.

Note that the multiplatform manifest is not visible in the Docker Hub UI, which can be reasonable confusing. The only way to find out the multiplatform manifest hash is to look at the logs of the `manifest` `push` GitHub Action Job. For an example, see here: https://github.com/stellar/quickstart/actions/runs/4609937251/jobs/8148632141#step:7:10

<img width="1072" alt="Screenshot 2023-04-04 at 12 32 31 PM" src="https://user-images.githubusercontent.com/351529/229900396-7573e432-1b6b-4b3c-9ff2-e06088c40501.png">
