### PR TITLE
Pin docker images to release version

### DIFF
--- a/docs/getting-started/deploy-to-a-local-network.mdx
+++ b/docs/getting-started/deploy-to-a-local-network.mdx
@@ -25,7 +25,7 @@ To run a local standalone network with the Stellar Quickstart Docker image, run 
 docker run --rm -it \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev \
+  stellar/quickstart:soroban-dev@sha256:a057ec6f06c6702c005693f8265ed1261e901b153a754e97cf18b0962257e872 \
   --standalone \
   --enable-soroban-rpc
 ```

--- a/docs/getting-started/deploy-to-futurenet.mdx
+++ b/docs/getting-started/deploy-to-futurenet.mdx
@@ -20,7 +20,7 @@ To run a local node for the [Futurenet] network with the Stellar Quickstart Dock
 docker run --rm -it \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev \
+  stellar/quickstart:soroban-dev@sha256:a057ec6f06c6702c005693f8265ed1261e901b153a754e97cf18b0962257e872 \
   --futurenet \
   --enable-soroban-rpc
 ```


### PR DESCRIPTION
### What
Pin docker images to release version.

### Why
Close #357

We didn't think this was possible previously because we published two versions an amd64 and an arm64, and it would have been inconvenient to show two commands in the docs. However, we recently discovered that we can use the multiplatform digest which allows us to pin the release version with a single digest, and when people use the digest their client will pick the right platform.