### PR TITLE
Update to Run the Example Atomic Swaps command

### DIFF
--- a/docs/how-to-guides/atomic-swap.mdx
+++ b/docs/how-to-guides/atomic-swap.mdx
@@ -33,7 +33,7 @@ Or, skip the development environment setup and open this example in [Gitpod][oig
 To run the tests for the example use `cargo test`.
 
 ```
-cargo test -p soroban-atomic-swap
+cargo test -p soroban-atomic-swap-contract
 ```
 
 You should see the output:


### PR DESCRIPTION
The command listed in the documentation of `cargo test -p soroban-atomic-swap` is incorrect. The correct command should be `cargo test -p soroban-atomic-swap-contract`