### PR TITLE
Added getLedgerEntries and deprecation warning for getLedgerEntry

### DIFF
--- a/api/methods/getLedgerEntries.mdx
+++ b/api/methods/getLedgerEntries.mdx
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 4
 ---
-:::note **This function is deprecated and will be removed in the next Soroban release. Please use getLedgerEntries instead.**
 For reading the current value of ledger entries directly.
 
 Allows you to directly inspect the _current state_ of a contract, a contract's code, or any other ledger entry. This is a backup way to access your contract data which may not be available via events or `simulateTransaction`.
@@ -10,13 +9,14 @@ To fetch contract wasm byte-code, use the ContractCode ledger entry key.
 
 ## Parameters
 
-- `key`: `<xdr.LedgerKey>` - The key of the ledger entry you wish to retrieve (serialized in a base64 string)
+- `keys`: `<xdr.LedgerKey[]>` - The keys of the ledger entries you wish to retrieve (serialized in a base64 string)
 
 ## Return
 
 - `<object>`
-  - `xdr`: `<xdr.LedgerEntryData>` - The current value of the given ledger entry  (serialized in a base64 string)
-  - `lastModifiedLedgerSeq`: `<number>` - The ledger number of the last time this entry was updated (optional)
+  - `entries`: `<object[]>` - Found ledger entries returned in the same order as given
+    - `xdr`: `<xdr.LedgerEntryData>` - The current value of this ledger entry  (serialized in a base64 string)
+    - `lastModifiedLedgerSeq`: `<number>` - The ledger number of the last time this entry was updated (optional)
   - `latestLedger`: `<number>` - The current latest ledger observed by the node when this response was generated.
 
 ## Examples
@@ -27,9 +27,11 @@ To fetch contract wasm byte-code, use the ContractCode ledger entry key.
 {
   "jsonrpc": "2.0",
   "id": 8675309,
-  "method": "getLedgerEntry",
+  "method": "getLedgerEntries",
   "params": {
-    "key": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAABQAAAAdDT1VOVEVSAA=="
+    "keys": [
+      "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAABQAAAAdDT1VOVEVSAA=="
+    ]
   }
 }
 ```
@@ -41,16 +43,20 @@ To fetch contract wasm byte-code, use the ContractCode ledger entry key.
   "jsonrpc": "2.0",
   "id": 8675309,
   "result": {
-    "xdr": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAABQAAAAdDT1VOVEVSAAAAAAEAAAAD",
-    "lastModifiedLedgerSeq": "164986",
+    "entries": [
+      {
+        "xdr": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAABQAAAAdDT1VOVEVSAAAAAAEAAAAD",
+        "lastModifiedLedgerSeq": "164986",
+      }
+    ],
     "latestLedger": "179436"
   }
 }
 ```
 
-### Generating `key` Parameters
+### Generating `keys` Parameters
 
-The example above is querying a deployment of the [`increment` example contract] to find out what value is stored in the `COUNTER` ledger entry. This value can be derived using the following code snippets. You should be able to extrapolate from the provided examples how to get `key` parameters for other types and values.
+The example above is querying a deployment of the [`increment` example contract] to find out what value is stored in the `COUNTER` ledger entry. This value can be derived using the following code snippets. You should be able to extrapolate from the provided examples how to get `keys` parameters for other types and values.
 
 #### Python
 
@@ -141,15 +147,17 @@ console.log(getLedgerKeyAccount(
 ```
 
 
-We then take our output from this function, and use it as the `key` parameter in our call to the `getLedgerEntry` method.
+We then take our output from this function, and use it as the `keys` parameter in our call to the `getLedgerEntries` method.
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 8675309,
-  "method": "getLedgerEntry",
+  "method": "getLedgerEntries",
   "params": {
-    "key": "AAAAAAAAAACp3BPIqFxM9XSnW6aHvavD3GWlJGfuylOt5tZL6CQtdQ=="
+    "keys": [
+      "AAAAAAAAAACp3BPIqFxM9XSnW6aHvavD3GWlJGfuylOt5tZL6CQtdQ=="
+    ]
   }
 }
 ```
@@ -161,8 +169,12 @@ And the response we get contains the `LedgerEntryData` with the current informat
   "jsonrpc": "2.0",
   "id": 8675309,
   "result": {
-    "xdr": "AAAAAAAAAACp3BPIqFxM9XSnW6aHvavD3GWlJGfuylOt5tZL6CQtdQAAABdIdugAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA"
-    "lastModifiedLedgerSeq": "164303",
+    "entries": [
+      {
+        "xdr": "AAAAAAAAAACp3BPIqFxM9XSnW6aHvavD3GWlJGfuylOt5tZL6CQtdQAAABdIdugAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA",
+        "lastModifiedLedgerSeq": "164303",
+      },
+    ],
     "latestLedger": "246819"
   }
 }
@@ -212,15 +224,17 @@ print(get_ledger_key_contract_code(
 # OUTPUT: AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAAAwAAAAM=
 ```
 
-We then take our output from this function, and use it as the `key` parameter in our call to the `getLedgerEntry` method.
+We then take our output from this function, and use it as the `keys` parameter in our call to the `getLedgerEntries` method.
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 8675309,
-  "method": "getLedgerEntry",
+  "method": "getLedgerEntries",
   "params": {
-    "key": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAAAwAAAAM="
+    "keys": [
+      "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAAAwAAAAM="
+    ]
   }
 }
 ```
@@ -232,8 +246,12 @@ And the response we get contains the `LedgerEntryData` that can be used to find 
   "jsonrpc": "2.0",
   "id": 8675309,
   "result": {
-    "xdr": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAAAwAAAAMAAAAEAAAAAQAAAAcAAAAA1CpZRz0BSN27PmqtsmBhv+AAJJwHgmrvJNPrHRAl9l8=",
-    "lastModifiedLedgerSeq": "164303",
+    "entries": [
+      {
+        "xdr": "AAAABhv6ziOnWcVRdGMZjtFKSWnLSndMp9JPVLLXxQqAvKqJAAAAAwAAAAMAAAAEAAAAAQAAAAcAAAAA1CpZRz0BSN27PmqtsmBhv+AAJJwHgmrvJNPrHRAl9l8=",
+        "lastModifiedLedgerSeq": "164303",
+      }
+    ],
     "latestLedger": "246819"
   }
 }
@@ -269,9 +287,11 @@ Now, finally we have a `LedgerKey` that correspond to the WASM byte-code that ha
 {
   "jsonrpc": "2.0",
   "id": 8675309,
-  "method": "getLedgerEntry",
+  "method": "getLedgerEntries",
   "params": {
-    "key": "AAAAB9QqWUc9AUjduz5qrbJgYb/gACScB4Jq7yTT6x0QJfZf"
+    "keys": [
+      "AAAAB9QqWUc9AUjduz5qrbJgYb/gACScB4Jq7yTT6x0QJfZf"
+    ]
   }
 }
 ```
@@ -283,8 +303,12 @@ And the response we get contains (even more) `LedgerEntryData` that we can decod
   "jsonrpc": "2.0",
   "id": 8675309,
   "result": {
-    "xdr": "AAAABwAAAADUKllHPQFI3bs+aq2yYGG/4AAknAeCau8k0+sdECX2XwAAAakAYXNtAQAAAAEXBWABfgF+YAJ+fgF+YAABfmABfwBgAAACEwMBbAEwAAABbAExAAABbAFfAAEDBgUCAwQEBAUDAQAQBhkDfwFBgIDAAAt/AEGAgMAAC38AQYCAwAALBzUFBm1lbW9yeQIACWluY3JlbWVudAADAV8ABwpfX2RhdGFfZW5kAwELX19oZWFwX2Jhc2UDAgrAAQWhAQMBfwF+AX8jgICAgABBEGsiACSAgICAAAJAAkBC2YP9sqDNAxCAgICAAEIVUg0AAkBC2YP9sqDNAxCBgICAACIBQg+DQgFSDQAgAUIEiKchAgwCCyAAQQhqEISAgIAAAAtBACECCwJAIAJBAWoiAg0AEIWAgIAAAAtC2YP9sqDNAyACrUIEhkIBhCIBEIKAgIAAGiAAQRBqJICAgIAAIAELCQAQhoCAgAAACwkAEIaAgIAAAAsEAAAACwIACwAeEWNvbnRyYWN0ZW52bWV0YXYwAAAAAAAAAAAAAAAbAC8OY29udHJhY3RzcGVjdjAAAAAAAAAACWluY3JlbWVudAAAAAAAAAAAAAABAAAAAQAAAA==",
-    "lastModifiedLedgerSeq": "164302",
+    "entries": [
+      {
+        "xdr": "AAAABwAAAADUKllHPQFI3bs+aq2yYGG/4AAknAeCau8k0+sdECX2XwAAAakAYXNtAQAAAAEXBWABfgF+YAJ+fgF+YAABfmABfwBgAAACEwMBbAEwAAABbAExAAABbAFfAAEDBgUCAwQEBAUDAQAQBhkDfwFBgIDAAAt/AEGAgMAAC38AQYCAwAALBzUFBm1lbW9yeQIACWluY3JlbWVudAADAV8ABwpfX2RhdGFfZW5kAwELX19oZWFwX2Jhc2UDAgrAAQWhAQMBfwF+AX8jgICAgABBEGsiACSAgICAAAJAAkBC2YP9sqDNAxCAgICAAEIVUg0AAkBC2YP9sqDNAxCBgICAACIBQg+DQgFSDQAgAUIEiKchAgwCCyAAQQhqEISAgIAAAAtBACECCwJAIAJBAWoiAg0AEIWAgIAAAAtC2YP9sqDNAyACrUIEhkIBhCIBEIKAgIAAGiAAQRBqJICAgIAAIAELCQAQhoCAgAAACwkAEIaAgIAAAAsEAAAACwIACwAeEWNvbnRyYWN0ZW52bWV0YXYwAAAAAAAAAAAAAAAbAC8OY29udHJhY3RzcGVjdjAAAAAAAAAACWluY3JlbWVudAAAAAAAAAAAAAABAAAAAQAAAA==",
+        "lastModifiedLedgerSeq": "164302",
+      }
+    ],
     "latestLedger": "246883"
   }
 }

--- a/sidebarsApi.js
+++ b/sidebarsApi.js
@@ -33,6 +33,7 @@ module.exports = {
         'methods/getHealth',
         'methods/getLatestLedger',
         'methods/getLedgerEntry',
+        'methods/getLedgerEntries',
         'methods/getNetwork',
         'methods/getTransaction',
         'methods/sendTransaction',


### PR DESCRIPTION
Adds getLedgerEntries to the docs and adds a deprecation warning for getLedgerEntry

Related to [this issue](https://github.com/stellar/soroban-tools/issues/374)

Need to wait until [this PR](https://github.com/stellar/soroban-tools/pull/587) is deployed to completely remove getLedgerEntry from the docs