### PR TITLE
Update the edition version in the Soroban Hello World Example

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -108,7 +108,7 @@ The steps below should produce a `Cargo.toml` that looks like so.
 [package]
 name = "project-name"
 version = "0.1.0"
-edition = "2022"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
@@ -360,8 +360,7 @@ This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/w
 
 The [hello world example] demonstrates how to write a simple contract, with a single function that takes one input and returns it as an output.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp] [oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
 
 [hello world example]: https://github.com/stellar/soroban-examples/tree/v0.7.0/hello_world
 


### PR DESCRIPTION
A user ran into an issue regarding an edition number in an example project that caused cargo to throw error due to incompatible Cargo version

```bash
Caused by:
  failed to parse the `edition` key

Caused by:
  this version of Cargo is older than the `2022` edition, and only supports `2015`, `2018`, and `2021` editions.

```
This pull request updates the edition [in the documentation](https://soroban.stellar.org/docs/getting-started/hello-world#wrapping-it-up) to meet the [latest cargo edition](https://www.rust-lang.org/) support, "2021"
