### PR TITLE
Improve Failure Condition Handling in Token Interface

### DIFF
--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -190,7 +190,7 @@ In the token interface, there are several instances where function calls can fai
 
 Its important to note the that the token interface not only incorporates the authorization concept for matching asset authorization in Stellar Classic, but it also utilizes the Soroban authorization mechanism. So, if you try to make a token call and it fails, it could be because of either token authorization processes. 
 
-To provide more context, when you use the token interface, there is a function called `authorized` that returns "true" if the address you're using has token authorization. 
+To provide more context, when you use the token interface, there is a function called `authorized` that returns "true" if an address has token authorization. 
 
 More details on Authorization can be found [here](../../learn/authorization).
 

--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -188,6 +188,9 @@ pub trait Contract {
 ### Handling Failure Conditions
 In the token interface, there are several instances where function calls can fail due to various reasons such as lack of proper authorization, insufficient allowance or balance, etc. To handle these failure conditions, it is important to specify the expected behavior when such situations arise.
 
+Its important to note the that the token interface not only incorporates the authorization concept for matching asset authorization in Stellar Classic, but it also utilizes the Soroban authorization mechanism. So, if you try to make a token call and it fails, it could be because of either token authorization processes. 
+More details on Authorization can be found [here](../../learn/authorization).
+
 For the functions in the token interface, [trapping](https://doc.rust-lang.org/book/ch09-00-error-handling.html) should be used as the standard way to handle failure conditions since the interface is not designed to return error codes. This means that when a function encounters an error, it will halt execution and revert any state changes that occurred during the function call.
 
 ### Failure Conditions
@@ -195,7 +198,7 @@ Here is a list of basic failure conditions and their expected behavior for funct
 
 #### Admin functions:
 
-- If the caller is not authorized as an admin, the function should trap.
+- If the admin did not authorize the call, the function should trap.
 - If the admin attempts to perform an invalid action (e.g., minting a negative amount), the function should trap.
 
 #### Token functions:

--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -189,6 +189,9 @@ pub trait Contract {
 In the token interface, there are several instances where function calls can fail due to various reasons such as lack of proper authorization, insufficient allowance or balance, etc. To handle these failure conditions, it is important to specify the expected behavior when such situations arise.
 
 Its important to note the that the token interface not only incorporates the authorization concept for matching asset authorization in Stellar Classic, but it also utilizes the Soroban authorization mechanism. So, if you try to make a token call and it fails, it could be because of either token authorization processes. 
+
+To provide more context, when you use the token interface, there is a function called `authorized` that returns "true" if the address you're using has token authorization. 
+
 More details on Authorization can be found [here](../../learn/authorization).
 
 For the functions in the token interface, [trapping](https://doc.rust-lang.org/book/ch09-00-error-handling.html) should be used as the standard way to handle failure conditions since the interface is not designed to return error codes. This means that when a function encounters an error, it will halt execution and revert any state changes that occurred during the function call.

--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -184,3 +184,48 @@ pub trait Contract {
     fn symbol(env: soroban_sdk::Env) -> soroban_sdk::Bytes;
 }
 ```
+
+### Handling Failure Conditions
+In the token interface, there are several instances where function calls can fail due to various reasons such as lack of proper authorization, insufficient allowance or balance, etc. To handle these failure conditions, it is important to specify the expected behavior when such situations arise.
+
+For the functions in the token interface, [trapping](https://doc.rust-lang.org/book/ch09-00-error-handling.html) should be used as the standard way to handle failure conditions since the interface is not designed to return error codes. This means that when a function encounters an error, it will halt execution and revert any state changes that occurred during the function call.
+
+### Failure Conditions
+Here is a list of basic failure conditions and their expected behavior for functions in the token interface:
+
+#### Admin functions:
+
+- If the caller is not authorized as an admin, the function should trap.
+- If the admin attempts to perform an invalid action (e.g., minting a negative amount), the function should trap.
+
+#### Token functions:
+
+- If the caller is not authorized to perform the action (e.g., transferring tokens without proper authorization), the function should trap.
+- If the action would result in an invalid state (e.g., transferring more tokens than available in the balance or allowance), the function should trap.
+
+### Example: Handling Insufficient Allowance in `burn_from` function
+
+In the `burn_from` function, the token contract should check whether the spender has enough allowance to burn the specified amount of tokens from the `from` address. If the allowance is insufficient, the function should trap, halting execution and reverting any state changes.
+
+Here's an example of how the `burn_from` function can be modified to handle this failure condition:
+
+```rust
+fn burn_from(
+    env: soroban_sdk::Env,
+    spender: Address,
+    from: Address,
+    amount: i128,
+) {
+    // Check if the spender has enough allowance
+    let current_allowance = allowance(env, from, spender);
+    if current_allowance < amount {
+        // Trap if the allowance is insufficient
+        panic!("Insufficient allowance");
+    }
+
+    // Proceed with burning tokens
+    // ...
+}
+```
+
+By clearly outlining how to handle failures and incorporating the right error management techniques in the token interface, we can make token contracts stronger and safer.


### PR DESCRIPTION
This pull request aims to enhance the handling of failure conditions in the token interface. Function calls can fail for various reasons, such as lack of proper authorization, insufficient allowance, or balance. To address these issues, we've specified the expected behavior when these situations occur.

Changes:
- Updated token interface documentation to include failure condition handling.
- Added example for handling insufficient allowance in the burn_from function.
- Modified the token interface functions to incorporate the proposed trapping mechanism.