### PR TITLE
update broken token spec link

### DIFF
--- a/docs/how-to-guides/stellar-asset-contract.mdx
+++ b/docs/how-to-guides/stellar-asset-contract.mdx
@@ -196,4 +196,4 @@ implementation.
 This interface can be found in the [SDK]. It extends the common 
 [token interface](tokens.mdx).
 
-[SDK]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-token-spec/src/lib.rs
+[SDK]: https://github.com/stellar/rs-soroban-sdk/blob/v0.7.0/soroban-token-spec/src/lib.rs


### PR DESCRIPTION
We are updating this page to fix a broken link and point users to the current soroban-token-spec resource