### PR TITLE
update target directories

### DIFF
--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -158,10 +158,10 @@ To build the contract, use the `cargo build` command.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `../target` directory:
+A `.wasm` file should be outputted in the `target` directory:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
 ```
 
 ## Run the Contract
@@ -170,7 +170,7 @@ If you have [`soroban-cli`] installed, you can invoke contract functions in the 
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
     --id 1 \
     -- \
     increment
@@ -186,7 +186,7 @@ Rerun the invoke with the `--footprint` option to view the [footprint] of the in
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
     --id 1 \
     --footprint \
     -- \

--- a/docs/how-to-guides/auth.mdx
+++ b/docs/how-to-guides/auth.mdx
@@ -298,7 +298,7 @@ To build the contract into a `.wasm` file, use the `cargo build` command.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-The `.wasm` file should be found in the `../target` directory after building:
+The `.wasm` file should be found in the `target` directory after building:
 
 ```
 target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm
@@ -332,7 +332,7 @@ identity name matching the address passed to the `--user` argument. This allows
 ```sh
 soroban contract invoke \
     --source acc1 \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     -- \
     increment \
@@ -345,7 +345,7 @@ Run a few more increments for both accounts.
 ```sh
 soroban contract invoke \
     --source acc2 \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     -- \
     increment \
@@ -356,7 +356,7 @@ soroban contract invoke \
 ```sh
 soroban contract invoke \
     --source acc1 \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     -- \
     increment \
@@ -367,7 +367,7 @@ soroban contract invoke \
 ```sh
 soroban contract invoke \
     --source acc2 \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     -- \
     increment \
@@ -392,7 +392,7 @@ providing `--auth` flag to the invocation:
 soroban contract invoke \
     --source acc2 \
     --auth \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_auth_contract.wasm \
     --id 1 \
     -- \
     increment \

--- a/docs/how-to-guides/cross-contract-call.mdx
+++ b/docs/how-to-guides/cross-contract-call.mdx
@@ -65,7 +65,7 @@ impl ContractA {
 
 ```rust title="cross_contract/contract_b/src/lib.rs"
 mod contract_a {
-    soroban_sdk::contractimport!(file = "../../target/wasm32-unknown-unknown/release/soroban_cross_contract_a_contract.wasm");
+    soroban_sdk::contractimport!(file = "../contract_a/target/wasm32-unknown-unknown/release/soroban_cross_contract_a_contract.wasm");
 }
 
 pub struct ContractB;
@@ -145,7 +145,7 @@ on Contract A.
 ```rust title="cross_contract_calls/src/a.rs"
 mod contract_a {
     soroban_sdk::contractimport!(
-        file = "../../target/wasm32-unknown-unknown/release/soroban_cross_contract_a_contract.wasm"
+        file = "../contract_a/target/wasm32-unknown-unknown/release/soroban_cross_contract_a_contract.wasm"
     );
 }
 
@@ -237,7 +237,7 @@ To build the contract into a `.wasm` file, use the `cargo build` command. Both
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-Both `.wasm` files should be found in the `../target` directory after building
+Both `.wasm` files should be found in both contract `target` directories after building
 both contracts:
 
 ```

--- a/docs/how-to-guides/custom-types.mdx
+++ b/docs/how-to-guides/custom-types.mdx
@@ -214,10 +214,10 @@ To build the contract, use the `cargo build` command.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `../target` directory:
+A `.wasm` file should be outputted in the `target` directory:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm
 ```
 
 ## Run the Contract
@@ -226,7 +226,7 @@ If you have [`soroban-cli`] installed, you can invoke contract functions in the 
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm \
     --id 1 \
     -- \
     increment \

--- a/docs/how-to-guides/deployer.mdx
+++ b/docs/how-to-guides/deployer.mdx
@@ -139,7 +139,7 @@ Open the `deployer/deployer/src/test.rs` file to follow along.
 // The contract that will be deployed by the deployer contract.
 mod contract {
     soroban_sdk::contractimport!(
-        file = "../../target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm"
+        file = "../contract/target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm"
     );
 }
 
@@ -171,7 +171,7 @@ file.
 ```rust
 mod contract {
     soroban_sdk::contractimport!(
-        file = "../../target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm"
+        file = "../contract/target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm"
     );
 }
 ```
@@ -263,15 +263,15 @@ both the deployer contract and the test contract.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-Both `.wasm` files should be found in the `../target` directory after building
+Both `.wasm` files should be found in both contract `target` directories after building
 both contracts:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_deployer_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_deployer_contract.wasm
 ```
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm
 ```
 
 ## Run the Contract

--- a/docs/how-to-guides/errors.mdx
+++ b/docs/how-to-guides/errors.mdx
@@ -297,10 +297,10 @@ To build the contract, use the `cargo build` command.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `../target` directory:
+A `.wasm` file should be outputted in the `target` directory:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm
 ```
 
 ## Run the Contract
@@ -310,7 +310,7 @@ WASM using it.
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_errors_contract.wasm \
     --id 1 \
     -- \
     increment

--- a/docs/how-to-guides/events.mdx
+++ b/docs/how-to-guides/events.mdx
@@ -219,10 +219,10 @@ To build the contract, use the `cargo build` command.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `../target` directory:
+A `.wasm` file should be outputted in the `target` directory:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_events_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_events_contract.wasm
 ```
 
 ## Run the Contract
@@ -232,7 +232,7 @@ using it.
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release/soroban_events_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release/soroban_events_contract.wasm \
     --id 1 \
     -- \
     increment

--- a/docs/how-to-guides/logging.mdx
+++ b/docs/how-to-guides/logging.mdx
@@ -234,11 +234,11 @@ To build the contract without logs, use the `--release` option.
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-A `.wasm` file should be outputted in the `../target` directory, in the
+A `.wasm` file should be outputted in the `target` directory, in the
 `release` subdirectory:
 
 ```
-../target/wasm32-unknown-unknown/release/soroban_logging_contract.wasm
+target/wasm32-unknown-unknown/release/soroban_logging_contract.wasm
 ```
 
 ### With Logs
@@ -249,11 +249,11 @@ To build the contract with logs, use the `--profile release-with-logs` option.
 cargo build --target wasm32-unknown-unknown --profile release-with-logs
 ```
 
-A `.wasm` file should be outputted in the `../target` directory, in the
+A `.wasm` file should be outputted in the `target` directory, in the
 `release-with-logs` subdirectory:
 
 ```
-../target/wasm32-unknown-unknown/release-with-logs/soroban_logging_contract.wasm
+target/wasm32-unknown-unknown/release-with-logs/soroban_logging_contract.wasm
 ```
 
 ## Run the Contract
@@ -263,7 +263,7 @@ using it.
 
 ```sh
 soroban contract invoke \
-    --wasm ../target/wasm32-unknown-unknown/release-with-logs/soroban_logging_contract.wasm \
+    --wasm target/wasm32-unknown-unknown/release-with-logs/soroban_logging_contract.wasm \
     --id 1 \
     -- \
     hello \


### PR DESCRIPTION
This PR updates the `soroban-examples` documentation to match upcoming changes in the directory structure. 

We're making changes to all examples, updating references to the target directory from `../target/wasm32-unknown-unknown/..` to `target/wasm32-unknown-unknown/....`

 Please review the changes and let me know if they are good to merrge. Thanks team.