### PR TITLE
fixes malformed hello world link

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -360,8 +360,9 @@ This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/w
 
 The [hello world example] demonstrates how to write a simple contract, with a single function that takes one input and returns it as an output.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp] [oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
 [hello world example]: https://github.com/stellar/soroban-examples/tree/v0.7.0/hello_world
 
 ## Optimizing Builds


### PR DESCRIPTION
This PR ensures that there is no extra syntax visible to the user and correctly displays the  "open in gitpod" button

Before:
<img width="917" alt="Screenshot 2023-05-04 at 4 21 07 PM" src="https://user-images.githubusercontent.com/73849597/236350248-818ea6ca-1879-4777-a8b5-79092cb8c02e.png">

After:
<img width="1005" alt="Screenshot 2023-05-04 at 4 23 02 PM" src="https://user-images.githubusercontent.com/73849597/236350456-4d7b16b0-577a-42df-b0d6-1344764f94f8.png">
