### PR TITLE
Fix CSS for the code block on the index page

### DIFF
--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -344,15 +344,10 @@ a.hp-link {
     margin-bottom: 2rem;
   }
 
-  &__right {
-    transform: translateX(5%);
-  }
-
   &__code {
     font-family: var(--ifm-font-family-mono);
     line-height: 150%;
 
-    width: 100vw;
     flex-shrink: 0;
     background-color: var(--primary-black);
     border: 1px solid var(--gray-5);


### PR DESCRIPTION
The width was set to 100vw, making it as wide as the whole screen, even when it was on the right-hand side of the page. Also, it was translated to the right by 5%, and I'm not entirely sure why, but it made for a goofy appearance on mobile.

@alejomendoza @jesmarsc should I check anything specific to see if this change breaks it?