### PR TITLE
Add note about contract meta to build-your-own-sdk page

### DIFF
--- a/docs/how-to-guides/build-your-own-sdk.mdx
+++ b/docs/how-to-guides/build-your-own-sdk.mdx
@@ -63,13 +63,17 @@ Enums with integer values should be translated into a `u32`.
 
 Errors are `u32` values that are translated into a [Status].
 
-### Meta Generation
+### Environment Meta Generation
 
 Contracts must contain a WASM custom section with name `contractenvmetav0` and containing a serialized [`SCEnvMetaEntry`]. The interface version stored within should match the version of the host functions supported.
 
 ### Contract Spec Generation
 
 Contracts should contain a WASM custom section with name `contractspecv0` and containing a serialized stream of [`SCSpecEntry`]. There should be a `SCSpecEntry` for every function, struct, and union exported by the contract.
+
+### Contract Meta Generation
+
+Contracts may optionally contain a WASM custom section with name `contractmetav0` and containing a serialized [`SCMetaEntry`]. Contracts may store any metadata in the entries that can be used by applications and tooling off-network.
 
 ## Testing
 

--- a/docs/how-to-guides/build-your-own-sdk.mdx
+++ b/docs/how-to-guides/build-your-own-sdk.mdx
@@ -96,3 +96,4 @@ The test environment should include:
 [Bytes]: https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-sdk/src/bytes.rs
 [`SCEnvMetaEntry`]: https://github.com/stellar/stellar-xdr/blob/next/Stellar-contract-env-meta.x
 [`SCSpecEntry`]: https://github.com/stellar/stellar-xdr/blob/next/Stellar-contract-spec.x
+[`SCMetaEntry`]: https://github.com/stellar/stellar-xdr/blob/next/Stellar-contract-meta.x


### PR DESCRIPTION
### What
Add note about contract meta to build-your-own-sdk page.

### Why
We've added the ability to store contract meta in contracts, and other SDKs that get built should provide it too.