### PR TITLE
update soroban-cli and example versions

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -360,9 +360,9 @@ This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/w
 
 The [hello world example] demonstrates how to write a simple contract, with a single function that takes one input and returns it as an output.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp] [oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp] [oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.8.4
 
-[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.7.0/hello_world
+[hello world example]: https://github.com/stellar/soroban-examples/tree/v0.8.4/hello_world
 
 ## Optimizing Builds
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -57,7 +57,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```sh
-cargo install --locked --version 0.7.0 soroban-cli
+cargo install --locked --version 0.8.0 soroban-cli
 ```
 
 :::info

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -7,18 +7,18 @@ description: Write a simple Soroban contract that stores and retrieves data.
 The [increment example] demonstrates how to write a simple contract that stores data, with a single function that increments an internal counter and returns the value.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.7.0
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.8.4
 
-[increment example]: https://github.com/stellar/soroban-examples/tree/v0.7.0/increment
+[increment example]: https://github.com/stellar/soroban-examples/tree/v0.8.4/increment
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v0.7.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v0.8.4` tag of `soroban-examples` repository:
 
 [Setup]: setup.mdx
 
 ```
-git clone -b v0.7.0 https://github.com/stellar/soroban-examples
+git clone -b v0.8.4 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -63,7 +63,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.7.0/increment
+Ref: https://github.com/stellar/soroban-examples/tree/v0.8.4/increment
 
 ## How it Works
 

--- a/docs/how-to-guides/atomic-swap.mdx
+++ b/docs/how-to-guides/atomic-swap.mdx
@@ -106,7 +106,7 @@ fn move_token(
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v0.7.0/atomic_swap
+Ref: https://github.com/stellar/soroban-examples/tree/v0.8.4/atomic_swap
 
 ## How it Works
 
@@ -175,7 +175,7 @@ contract invocation.
 
 Open the [`atomic_swap/src/test.rs`] file to follow along.
 
-[`atomic_swap/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v0.7.0/atomic_swap/src/test.rs
+[`atomic_swap/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v0.8.4/atomic_swap/src/test.rs
 
 Refer to another examples for the general information on the test setup.
 

--- a/docs/how-to-guides/stellar-asset-contract.mdx
+++ b/docs/how-to-guides/stellar-asset-contract.mdx
@@ -192,4 +192,4 @@ implementation.
 This interface can be found in the [SDK]. It extends the common 
 [token interface](tokens.mdx).
 
-[SDK]: https://github.com/stellar/rs-soroban-sdk/blob/v0.7.0/soroban-token-spec/src/lib.rs
+[SDK]: https://github.com/stellar/rs-soroban-sdk/blob/v0.8.4/soroban-sdk/src/token.rs


### PR DESCRIPTION
This PR updates the following:
- Update links in docs from `examples/tree/v0.7.0` to `examples/tree/0.8.4`
- Directs users to install `soroban-cli v0.8.0`
- Updates the token contract interface link to `v0.8.4/soroban-sdk/src/token.rs`

