### PR TITLE
Update quickstart version in preview 9 release notes

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -31,7 +31,7 @@ Preview releases are software releases that are also released to the [Futurenet]
 | Soroban RPC | `v0.8.0` |
 | Stellar Horizon | `stellar-horizon:2.25.1~soroban-346` |
 | Stellar Friendbot | `soroban-v0.0.2-alpha` |
-| Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:523330bdf2c41e04a6ad8f7891435edf6b4530e465570e2f57daa5a309b92d5b` |
+| Stellar Quickstart | `stellar/quickstart:soroban-dev@sha256:1b7317be1eadc28461f4cc9ac93b5c223ccd638b2628b3693bcec6ac46fbc618` |
 | Stellar JS Stellar Base | `9.0.0-soroban.1` |
 | Stellar JS Soroban Client | `0.7.0` |
 | Freighter | todo |


### PR DESCRIPTION
### What

Update quickstart version in preview 9 release notes.

### Why

A fix to quickstart was pushed in https://github.com/stellar/quickstart/pull/454. The version in this change is from https://github.com/stellar/quickstart/actions/runs/5072845781/jobs/9111898830#step:7:10.

