### PR TITLE
Change command recommended for building .wasm files for deployment

### DIFF
--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -985,10 +985,10 @@ conditions and ensure the contract responds appropriately to each one:
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ```bash
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -985,10 +985,10 @@ conditions and ensure the contract responds appropriately to each one:
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ```bash
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -985,10 +985,10 @@ conditions and ensure the contract responds appropriately to each one:
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ```bash
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/auth.mdx
+++ b/docs/basic-tutorials/auth.mdx
@@ -292,10 +292,10 @@ assert_eq!(client.increment(&user_2, &4), 5);
 
 ## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo build` command.
+To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 The `.wasm` file should be found in the `target` directory after building:

--- a/docs/basic-tutorials/auth.mdx
+++ b/docs/basic-tutorials/auth.mdx
@@ -292,10 +292,10 @@ assert_eq!(client.increment(&user_2, &4), 5);
 
 ## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo rustc` command.
+To build the contract into a `.wasm` file, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 The `.wasm` file should be found in the `target` directory after building:

--- a/docs/basic-tutorials/auth.mdx
+++ b/docs/basic-tutorials/auth.mdx
@@ -292,10 +292,10 @@ assert_eq!(client.increment(&user_2, &4), 5);
 
 ## Build the Contract
 
-To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract into a `.wasm` file, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 The `.wasm` file should be found in the `target` directory after building:

--- a/docs/basic-tutorials/cross-contract-call.mdx
+++ b/docs/basic-tutorials/cross-contract-call.mdx
@@ -231,11 +231,11 @@ assert_eq!(sum, 12);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo rustc` command. Both
+To build the contract into a `.wasm` file, use the `soroban contract build` command. Both
 `contract_call/contract_a` and `contract_call/contract_b` must be built, with `contract_a` being built first.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/cross-contract-call.mdx
+++ b/docs/basic-tutorials/cross-contract-call.mdx
@@ -231,11 +231,11 @@ assert_eq!(sum, 12);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command. Both
+To build the contract into a `.wasm` file, use the `cargo rustc` command. Both
 `contract_call/contract_a` and `contract_call/contract_b` must be built, with `contract_a` being built first.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/cross-contract-call.mdx
+++ b/docs/basic-tutorials/cross-contract-call.mdx
@@ -231,11 +231,11 @@ assert_eq!(sum, 12);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo build` command. Both
+To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command. Both
 `contract_call/contract_a` and `contract_call/contract_b` must be built, with `contract_a` being built first.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/custom-types.mdx
+++ b/docs/basic-tutorials/custom-types.mdx
@@ -222,10 +222,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/custom-types.mdx
+++ b/docs/basic-tutorials/custom-types.mdx
@@ -222,10 +222,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/custom-types.mdx
+++ b/docs/basic-tutorials/custom-types.mdx
@@ -222,10 +222,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/deployer.mdx
+++ b/docs/basic-tutorials/deployer.mdx
@@ -263,11 +263,11 @@ assert_eq!(sum, 5);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo rustc` command. Build
+To build the contract into a `.wasm` file, use the `soroban contract build` command. Build
 both the deployer contract and the test contract.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/deployer.mdx
+++ b/docs/basic-tutorials/deployer.mdx
@@ -263,11 +263,11 @@ assert_eq!(sum, 5);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command. Build
+To build the contract into a `.wasm` file, use the `cargo rustc` command. Build
 both the deployer contract and the test contract.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/deployer.mdx
+++ b/docs/basic-tutorials/deployer.mdx
@@ -263,11 +263,11 @@ assert_eq!(sum, 5);
 
 ## Build the Contracts
 
-To build the contract into a `.wasm` file, use the `cargo build` command. Build
+To build the contract into a `.wasm` file, use the `cargo rustc build --crate-type cdylib` command. Build
 both the deployer contract and the test contract.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Both `.wasm` files should be found in both contract `target` directories after building

--- a/docs/basic-tutorials/errors.mdx
+++ b/docs/basic-tutorials/errors.mdx
@@ -302,10 +302,10 @@ client.increment();
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/errors.mdx
+++ b/docs/basic-tutorials/errors.mdx
@@ -302,10 +302,10 @@ client.increment();
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/errors.mdx
+++ b/docs/basic-tutorials/errors.mdx
@@ -302,10 +302,10 @@ client.increment();
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/events.mdx
+++ b/docs/basic-tutorials/events.mdx
@@ -228,10 +228,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/events.mdx
+++ b/docs/basic-tutorials/events.mdx
@@ -228,10 +228,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/events.mdx
+++ b/docs/basic-tutorials/events.mdx
@@ -228,10 +228,10 @@ assert_eq!(
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/basic-tutorials/logging.mdx
+++ b/docs/basic-tutorials/logging.mdx
@@ -224,14 +224,14 @@ std::println!("{}", logs.join("\n"));
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ### Without Logs
 
 To build the contract without logs, use the `--release` option.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the
@@ -246,7 +246,7 @@ target/wasm32-unknown-unknown/release/soroban_logging_contract.wasm
 To build the contract with logs, use the `--profile release-with-logs` option.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --profile release-with-logs
+soroban contract build --crate-type cdylib --target wasm32-unknown-unknown --profile release-with-logs
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the

--- a/docs/basic-tutorials/logging.mdx
+++ b/docs/basic-tutorials/logging.mdx
@@ -224,14 +224,14 @@ std::println!("{}", logs.join("\n"));
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ### Without Logs
 
 To build the contract without logs, use the `--release` option.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the
@@ -246,7 +246,7 @@ target/wasm32-unknown-unknown/release/soroban_logging_contract.wasm
 To build the contract with logs, use the `--profile release-with-logs` option.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --profile release-with-logs
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --profile release-with-logs
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the

--- a/docs/basic-tutorials/logging.mdx
+++ b/docs/basic-tutorials/logging.mdx
@@ -224,14 +224,14 @@ std::println!("{}", logs.join("\n"));
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ### Without Logs
 
 To build the contract without logs, use the `--release` option.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the
@@ -246,7 +246,7 @@ target/wasm32-unknown-unknown/release/soroban_logging_contract.wasm
 To build the contract with logs, use the `--profile release-with-logs` option.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --profile release-with-logs
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --profile release-with-logs
 ```
 
 A `.wasm` file should be outputted in the `target` directory, in the

--- a/docs/basic-tutorials/upgrading-contracts.mdx
+++ b/docs/basic-tutorials/upgrading-contracts.mdx
@@ -160,7 +160,7 @@ assert_eq!(2, client.version());
 
 ## Build the Contract
 
-To build the contract `.wasm` files, run `cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release` in both
+To build the contract `.wasm` files, run `soroban contract build` in both
 `upgradeable_contract/old_contract` and `upgradeable_contract/new_contract` in
 that order.
 

--- a/docs/basic-tutorials/upgrading-contracts.mdx
+++ b/docs/basic-tutorials/upgrading-contracts.mdx
@@ -160,7 +160,7 @@ assert_eq!(2, client.version());
 
 ## Build the Contract
 
-To build the contract `.wasm` files, run `cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release` in both
+To build the contract `.wasm` files, run `cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release` in both
 `upgradeable_contract/old_contract` and `upgradeable_contract/new_contract` in
 that order.
 

--- a/docs/basic-tutorials/upgrading-contracts.mdx
+++ b/docs/basic-tutorials/upgrading-contracts.mdx
@@ -160,7 +160,7 @@ assert_eq!(2, client.version());
 
 ## Build the Contract
 
-To build the contract `.wasm` files, run `cargo build --target wasm32-unknown-unknown --release` in both
+To build the contract `.wasm` files, run `cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release` in both
 `upgradeable_contract/old_contract` and `upgradeable_contract/new_contract` in
 that order.
 

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -204,7 +204,7 @@ cd soroban-examples/token
 Next, build the Token contract using the following command:
 
 ```bash
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 This will build the `soroban_token_contract.wasm` file which you will need to import into your project. The `soroban_token_contract.wasm` file is located in the `soroban-examples/target/wasm32-unknown-unknown/release` directory.
@@ -914,7 +914,7 @@ Below you will find a series of commands that will help you build, deploy and in
 <TabItem value="build" label="build.sh">
 
 ```bash
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 </TabItem>
@@ -1090,7 +1090,7 @@ First, we need to build the vault contract. We can do this by running the `build
 
 ```bash
 ##cd vault
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Next, we need to deploy the token contract. We can do this by running the `deploy_token.sh` script.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -251,6 +251,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 soroban-sdk = { version = "0.8.4" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -204,7 +204,7 @@ cd soroban-examples/token
 Next, build the Token contract using the following command:
 
 ```bash
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 This will build the `soroban_token_contract.wasm` file which you will need to import into your project. The `soroban_token_contract.wasm` file is located in the `soroban-examples/target/wasm32-unknown-unknown/release` directory.
@@ -911,7 +911,7 @@ Below you will find a series of commands that will help you build, deploy and in
 <TabItem value="build" label="build.sh">
 
 ```bash
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 </TabItem>
@@ -1087,7 +1087,7 @@ First, we need to build the vault contract. We can do this by running the `build
 
 ```bash
 ##cd vault
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 Next, we need to deploy the token contract. We can do this by running the `deploy_token.sh` script.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -251,9 +251,6 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
 soroban-sdk = { version = "0.8.4" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -204,7 +204,7 @@ cd soroban-examples/token
 Next, build the Token contract using the following command:
 
 ```bash
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 This will build the `soroban_token_contract.wasm` file which you will need to import into your project. The `soroban_token_contract.wasm` file is located in the `soroban-examples/target/wasm32-unknown-unknown/release` directory.
@@ -911,7 +911,7 @@ Below you will find a series of commands that will help you build, deploy and in
 <TabItem value="build" label="build.sh">
 
 ```bash
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 </TabItem>
@@ -1087,7 +1087,7 @@ First, we need to build the vault contract. We can do this by running the `build
 
 ```bash
 ##cd vault
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 Next, we need to deploy the token contract. We can do this by running the `deploy_token.sh` script.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -570,6 +570,9 @@ name = "increment"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = ["cdylib"]
+
 [features]
 testutils = ["soroban-sdk/testutils"]
 

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -599,11 +599,11 @@ debug-assertions = true
 
 > _Note_: For a detailed explanation of the `Cargo.toml` configuration used in this tutorial, check out the [Hello World Example](../../getting-started/hello-world#import-soroban-sdk-and-features).
 
-Next, build the project using the `cargo build` command.
+Next, build the project using the `cargo rustc build --crate-type cdylib` command.
 
 ```bash
 cd increment
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 The compiled contract will be located in the `target/wasm32-unknown-unknown/release` directory.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -596,11 +596,11 @@ debug-assertions = true
 
 > _Note_: For a detailed explanation of the `Cargo.toml` configuration used in this tutorial, check out the [Hello World Example](../../getting-started/hello-world#import-soroban-sdk-and-features).
 
-Next, build the project using the `cargo rustc build --crate-type cdylib` command.
+Next, build the project using the `cargo rustc` command.
 
 ```bash
 cd increment
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 The compiled contract will be located in the `target/wasm32-unknown-unknown/release` directory.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -596,11 +596,11 @@ debug-assertions = true
 
 > _Note_: For a detailed explanation of the `Cargo.toml` configuration used in this tutorial, check out the [Hello World Example](../../getting-started/hello-world#import-soroban-sdk-and-features).
 
-Next, build the project using the `cargo rustc` command.
+Next, build the project using the `soroban contract build` command.
 
 ```bash
 cd increment
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 The compiled contract will be located in the `target/wasm32-unknown-unknown/release` directory.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -570,9 +570,6 @@ name = "increment"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [features]
 testutils = ["soroban-sdk/testutils"]
 

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -28,6 +28,15 @@ version = "0.1.0"
 edition = "2021"
 ```
 
+### Configure the Library Type
+
+Add the `crate-type` configuration, required for building contracts.
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
 ### Import `soroban-sdk` and Features
 
 Add the following sections to the `Cargo.toml` that will import the `soroban-sdk`, and configure a set of features explained below.
@@ -100,6 +109,9 @@ The steps below should produce a `Cargo.toml` that looks like so.
 name = "project-name"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -278,10 +278,10 @@ Try changing the values in the test to see how it works.
 
 ## Build
 
-To build a Soroban contract to deploy or run, use the `cargo rustc build --crate-type cdylib` command.
+To build a Soroban contract to deploy or run, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 :::tip

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -28,15 +28,6 @@ version = "0.1.0"
 edition = "2021"
 ```
 
-### Configure the Library Type
-
-Add the `crate-type` configuration, required for building contracts.
-
-```toml
-[lib]
-crate-type = ["cdylib"]
-```
-
 ### Import `soroban-sdk` and Features
 
 Add the following sections to the `Cargo.toml` that will import the `soroban-sdk`, and configure a set of features explained below.
@@ -109,9 +100,6 @@ The steps below should produce a `Cargo.toml` that looks like so.
 name = "project-name"
 version = "0.1.0"
 edition = "2021"
-
-[lib]
-crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -278,10 +278,10 @@ Try changing the values in the test to see how it works.
 
 ## Build
 
-To build a Soroban contract to deploy or run, use the `cargo rustc` command.
+To build a Soroban contract to deploy or run, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 :::tip

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -290,10 +290,10 @@ Try changing the values in the test to see how it works.
 
 ## Build
 
-To build a Soroban contract to deploy or run, use the `cargo build` command.
+To build a Soroban contract to deploy or run, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 :::tip

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -152,10 +152,10 @@ assert_eq!(client.increment(), 1);
 
 ## Build the Contract
 
-To build the contract, use the `cargo build` command.
+To build the contract, use the `cargo rustc build --crate-type cdylib` command.
 
 ```sh
-cargo build --target wasm32-unknown-unknown --release
+cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -152,10 +152,10 @@ assert_eq!(client.increment(), 1);
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc build --crate-type cdylib` command.
+To build the contract, use the `cargo rustc` command.
 
 ```sh
-cargo rustc build --crate-type cdylib --target wasm32-unknown-unknown --release
+cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
 ```
 
 A `.wasm` file should be outputted in the `target` directory:

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -152,10 +152,10 @@ assert_eq!(client.increment(), 1);
 
 ## Build the Contract
 
-To build the contract, use the `cargo rustc` command.
+To build the contract, use the `soroban contract build` command.
 
 ```sh
-cargo rustc --crate-type cdylib --target wasm32-unknown-unknown --release
+soroban contract build
 ```
 
 A `.wasm` file should be outputted in the `target` directory:


### PR DESCRIPTION
### What
Change command recommended for building .wasm files for deployment

### Why
Cargo/rust has an feature (not a bug unfortunately) that if a crate has multiple `crate-type`s, like `cdylib` (wasm file) and `rlib` (importable library), link time optimizations (LTO) will be disabled for the `cdylib` build. In our experience this results in larger wasm files. See these issues for more information:
- https://github.com/rust-lang/cargo/issues/2301#issuecomment-228195264
- https://github.com/rust-lang/cargo/issues/4611

We've avoided recommending any setups that result in a contract crate having multiple `crate-type`s because of this. Contracts need the `cdylib` `crate-type` so that they build to wasm. Usually this has meant avoiding any situation where the contract would be imported into another crate, so as to avoid the need for `crate-type` `rlib`. 

However, with the addition of fuzzing (https://github.com/stellar/rs-soroban-sdk/pull/957) we can't really say no to contracts needing to have `rlib`. The standard way to do fuzzing is to import the crate into another crate.

@graydon identified that folks can use the `cargo rustc` command, which is a more advanced version of `cargo build` to pass a specific `crate-type` to the compiler overriding any `crate-type`s defined in the crate. By doing this someone can build their contract only for `cdylib` which ensures LTO are still enabled.

The soroban-cli build command calls out to rustc.

If developers still use `cargo build`, the end result will not be catastrophic, but the contract will be more expensive to use.

Related to https://github.com/stellar/soroban-tools/pull/713

Related to https://github.com/stellar/soroban-examples/pull/258

### Status

This change is not ready to be merged as it needs feedback from a wider group.