### PR TITLE
Fixing a missing link in the markdown of the `tokens` how-to guide

### DIFF
--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -1010,3 +1010,5 @@ soroban contract invoke \
     balance \
     --id GBZV3NONYSUDVTEHATQO4BCJVFXJO3XQU5K32X3XREVZKSMMOZFO4ZXR
 ```
+
+[`soroban-cli`]: ../reference/soroban-cli


### PR DESCRIPTION
We have a link to the soroban-cli that doesn't actually have a definition anywhere. This commit fixes that.