### PR TITLE
More fixes

### DIFF
--- a/docs/advanced-tutorials/atomic-swap.mdx
+++ b/docs/advanced-tutorials/atomic-swap.mdx
@@ -158,16 +158,24 @@ fn move_token(
     token: &Address,
     from: &Address,
     to: &Address,
-    approve_amount: i128,
-    xfer_amount: i128,
+    max_spend_amount: i128,
+    transfer_amount: i128,
 ) {
     let token = token::Client::new(env, token);
     let contract_address = env.current_contract_address();
-    // This call needs to be authorized by `from` address. Since it increases
-    // the allowance on behalf of the contract, `from` doesn't need to know `to`
-    // at the signature time.
-    token.incr_allow(from, &contract_address, &approve_amount);
-    token.xfer_from(&contract_address, from, to, &xfer_amount);
+    // This call needs to be authorized by `from` address. It transfers the
+    // maximum spend amount to the swap contract's address in order to decouple
+    // the signature from `to` address (so that parties don't need to know each
+    // other).
+    token.transfer(from, &contract_address, &max_spend_amount);
+    // Transfer the necessary amount to `to`.
+    token.transfer(&contract_address, to, &transfer_amount);
+    // Refund the remaining balance to `from`.
+    token.transfer(
+        &contract_address,
+        from,
+        &(&max_spend_amount - &transfer_amount),
+    );
 }
 ```
 
@@ -193,8 +201,8 @@ The interesting part for this example is verification of `swap` authorization:
 contract.swap(
     &a,
     &b,
-    &token_a.contract_id,
-    &token_b.contract_id,
+    &token_a.address,
+    &token_b.address,
     &1000,
     &4500,
     &5000,
@@ -206,39 +214,51 @@ assert_eq!(
     std::vec![
         (
             a.clone(),
-            contract.address.clone(),
-            Symbol::short("swap"),
-            (
-                token_a.address.clone(),
-                token_b.address.clone(),
-                1000_i128,
-                4500_i128
-            )
-                .into_val(&env),
-        ),
-        (
-            a.clone(),
-            token_a.address.clone(),
-            Symbol::new(&env, "increase_allowance"),
-            (a.clone(), &contract.address, 1000_i128).into_val(&env),
-        ),
-        (
-            b.clone(),
-            contract.address.clone(),
-            Symbol::short("swap"),
-            (
-                token_b.address.clone(),
-                token_a.address.clone(),
-                5000_i128,
-                950_i128
-            )
-                .into_val(&env),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    contract.address.clone(),
+                    symbol_short!("swap"),
+                    (
+                        token_a.address.clone(),
+                        token_b.address.clone(),
+                        1000_i128,
+                        4500_i128
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        token_a.address.clone(),
+                        symbol_short!("transfer"),
+                        (a.clone(), contract.address.clone(), 1000_i128,).into_val(&env),
+                    )),
+                    sub_invocations: std::vec![]
+                }]
+            }
         ),
         (
             b.clone(),
-            token_b.address.clone(),
-            Symbol::new(&env, "increase_allowance"),
-            (b.clone(), &contract.address, 5000_i128).into_val(&env),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    contract.address.clone(),
+                    symbol_short!("swap"),
+                    (
+                        token_b.address.clone(),
+                        token_a.address.clone(),
+                        5000_i128,
+                        950_i128
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        token_b.address.clone(),
+                        symbol_short!("transfer"),
+                        (b.clone(), contract.address.clone(), 5000_i128,).into_val(&env),
+                    )),
+                    sub_invocations: std::vec![]
+                }]
+            }
         ),
     ]
 );
@@ -246,5 +266,5 @@ assert_eq!(
 
 `env.auths()` returns all the authorizations. In the case of `swap` four
 authorizations are expected. Two for each address authorizing, because each
-address authorizes not only the swap, but the `increase_allowance` all on the
+address authorizes not only the swap, but the `approve` all on the
 token being sent.

--- a/docs/advanced-tutorials/custom-account.mdx
+++ b/docs/advanced-tutorials/custom-account.mdx
@@ -94,9 +94,11 @@ pub fn init(env: Env, signers: Vec<BytesN<32>>) {
     // In reality this would need some additional validation on signers
     // (deduplication etc.).
     for signer in signers.iter() {
-        env.storage().set(&DataKey::Signer(signer.unwrap()), &());
+        env.storage().instance().set(&DataKey::Signer(signer), &());
     }
-    env.storage().set(&DataKey::SignerCnt, &signers.len());
+    env.storage()
+        .instance()
+        .set(&DataKey::SignerCnt, &signers.len());
 }
 ```
 
@@ -115,7 +117,9 @@ pub fn add_limit(env: Env, token: BytesN<32>, limit: i128) {
     // authorize the call on its own behalf and that wouldn't require any
     // user-side verification.
     env.current_contract_address().require_auth();
-    env.storage().set(&DataKey::SpendLimit(token), &limit);
+    env.storage()
+            .instance()
+            .set(&DataKey::SpendLimit(token), &limit);
 }
 ```
 
@@ -137,7 +141,11 @@ pub fn __check_auth(
     // Perform authentication.
     authenticate(&env, &signature_payload, &signatures)?;
 
-    let tot_signers: u32 = env.storage().get(&DataKey::SignerCnt).unwrap().unwrap();
+    let tot_signers: u32 = env
+        .storage()
+        .instance()
+        .get::<_, u32>(&DataKey::SignerCnt)
+        .unwrap();
     let all_signed = tot_signers == signatures.len();
 
     let curr_contract = env.current_contract_address();
@@ -146,12 +154,12 @@ pub fn __check_auth(
     // makes sure that if e.g. multiple `transfer` calls are being authorized
     // for the same token we still respect the limit for the total
     // transferred amount (and not the 'per-call' limits).
-    let mut spend_left_per_token = Map::<BytesN<32>, i128>::new(&env);
+    let mut spend_left_per_token = Map::<Address, i128>::new(&env);
     // Verify the authorization policy.
     for context in auth_context.iter() {
         verify_authorization_policy(
             &env,
-            &context.unwrap(),
+            &context,
             &curr_contract,
             all_signed,
             &mut spend_left_per_token,
@@ -187,15 +195,16 @@ fn authenticate(
     signatures: &Vec<Signature>,
 ) -> Result<(), AccError> {
     for i in 0..signatures.len() {
-        let signature = signatures.get_unchecked(i).unwrap();
+        let signature = signatures.get_unchecked(i);
         if i > 0 {
-            let prev_signature = signatures.get_unchecked(i - 1).unwrap();
+            let prev_signature = signatures.get_unchecked(i - 1);
             if prev_signature.public_key >= signature.public_key {
                 return Err(AccError::BadSignatureOrder);
             }
         }
         if !env
             .storage()
+            .instance()
             .has(&DataKey::Signer(signature.public_key.clone()))
         {
             return Err(AccError::UnknownSigner);
@@ -317,13 +326,13 @@ payloads.
 ```rust
 let payload = BytesN::random(&env);
 let token = BytesN::random(&env);
-env.invoke_account_contract_check_auth::<AccError>(
-    &account_contract.contract_id,
+env.try_invoke_contract_check_auth::<AccError>(
+    &account_contract.address.contract_id(),
     &payload,
     &vec![&env, sign(&env, &signers[0], &payload)],
     &vec![
         &env,
-        token_auth_context(&env, &token, Symbol::new(&env, "xfer"), 1000),
+        token_auth_context(&env, &token, Symbol::new(&env, "transfer"), 1000),
     ],
 )
 .unwrap();

--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -88,17 +88,17 @@ use soroban_sdk::{Address, Env};
 
 pub fn has_administrator(e: &Env) -> bool {
     let key = DataKey::Admin;
-    e.storage().has(&key)
+    e.storage().instance().has(&key)
 }
 
 pub fn read_administrator(e: &Env) -> Address {
     let key = DataKey::Admin;
-    e.storage().get_unchecked(&key).unwrap()
+    e.storage().instance().get(&key).unwrap()
 }
 
 pub fn write_administrator(e: &Env, id: &Address) {
     let key = DataKey::Admin;
-    e.storage().set(&key, id);
+    e.storage().instance().set(&key, id);
 }
 ```
 
@@ -106,29 +106,69 @@ pub fn write_administrator(e: &Env, id: &Address) {
 <TabItem value="allowance">
 
 ```rust title="token/src/allowance.rs"
-use crate::storage_types::{AllowanceDataKey, DataKey};
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
 use soroban_sdk::{Address, Env};
 
-pub fn read_allowance(e: &Env, from: Address, spender: Address) -> i128 {
+pub fn read_allowance(e: &Env, from: Address, spender: Address) -> AllowanceValue {
     let key = DataKey::Allowance(AllowanceDataKey { from, spender });
-    if let Some(allowance) = e.storage().get(&key) {
-        allowance.unwrap()
+    if let Some(allowance) = e.storage().temporary().get::<_, AllowanceValue>(&key) {
+        if allowance.expiration_ledger < e.ledger().sequence() {
+            AllowanceValue {
+                amount: 0,
+                expiration_ledger: allowance.expiration_ledger,
+            }
+        } else {
+            allowance
+        }
     } else {
-        0
+        AllowanceValue {
+            amount: 0,
+            expiration_ledger: 0,
+        }
     }
 }
 
-pub fn write_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
+pub fn write_allowance(
+    e: &Env,
+    from: Address,
+    spender: Address,
+    amount: i128,
+    expiration_ledger: u32,
+) {
+    let allowance = AllowanceValue {
+        amount,
+        expiration_ledger,
+    };
+
+    if amount > 0 && expiration_ledger < e.ledger().sequence() {
+        panic!("expiration_ledger is less than ledger seq when amount > 0")
+    }
+
     let key = DataKey::Allowance(AllowanceDataKey { from, spender });
-    e.storage().set(&key, &amount);
+    e.storage().temporary().set(&key.clone(), &allowance);
+
+    if amount > 0 {
+        e.storage().temporary().bump(
+            &key,
+            expiration_ledger
+                .checked_sub(e.ledger().sequence())
+                .unwrap(),
+        )
+    }
 }
 
 pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
     let allowance = read_allowance(e, from.clone(), spender.clone());
-    if allowance < amount {
+    if allowance.amount < amount {
         panic!("insufficient allowance");
     }
-    write_allowance(e, from, spender, allowance - amount);
+    write_allowance(
+        e,
+        from,
+        spender,
+        allowance.amount - amount,
+        allowance.expiration_ledger,
+    );
 }
 ```
 
@@ -141,8 +181,8 @@ use soroban_sdk::{Address, Env};
 
 pub fn read_balance(e: &Env, addr: Address) -> i128 {
     let key = DataKey::Balance(addr);
-    if let Some(balance) = e.storage().get(&key) {
-        balance.unwrap()
+    if let Some(balance) = e.storage().persistent().get::<DataKey, i128>(&key) {
+        balance
     } else {
         0
     }
@@ -150,7 +190,7 @@ pub fn read_balance(e: &Env, addr: Address) -> i128 {
 
 fn write_balance(e: &Env, addr: Address, amount: i128) {
     let key = DataKey::Balance(addr);
-    e.storage().set(&key, &amount);
+    e.storage().persistent().set(&key, &amount);
 }
 
 pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
@@ -174,8 +214,8 @@ pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
 
 pub fn is_authorized(e: &Env, addr: Address) -> bool {
     let key = DataKey::State(addr);
-    if let Some(state) = e.storage().get(&key) {
-        state.unwrap()
+    if let Some(state) = e.storage().persistent().get::<DataKey, bool>(&key) {
+        state
     } else {
         true
     }
@@ -183,7 +223,7 @@ pub fn is_authorized(e: &Env, addr: Address) -> bool {
 
 pub fn write_authorization(e: &Env, addr: Address, is_authorized: bool) {
     let key = DataKey::State(addr);
-    e.storage().set(&key, &is_authorized);
+    e.storage().persistent().set(&key, &is_authorized);
 }
 ```
 
@@ -244,6 +284,7 @@ fn check_nonnegative_amount(amount: i128) {
     }
 }
 
+#[contract]
 pub struct Token;
 
 #[contractimpl]
@@ -453,6 +494,12 @@ use soroban_sdk::{contracttype, Address};
 pub struct AllowanceDataKey {
     pub from: Address,
     pub spender: Address,
+}
+
+#[contracttype]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expiration_ledger: u32,
 }
 
 #[derive(Clone)]
@@ -770,7 +817,7 @@ fn test() {
     );
     assert_eq!(token.balance(&user3), 200);
 
-    // Increase to 500
+    // Set allowance to 500
     token.approve(&user2, &user3, &500, &200);
     assert_eq!(token.allowance(&user2, &user3), 500);
     token.approve(&user2, &user3, &0, &200);

--- a/docs/basic-tutorials/auth.mdx
+++ b/docs/basic-tutorials/auth.mdx
@@ -52,6 +52,7 @@ pub enum DataKey {
     Counter(Address),
 }
 
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -82,17 +83,13 @@ impl IncrementContract {
         let key = DataKey::Counter(user.clone());
 
         // Get the current count for the invoker.
-        let mut count: u32 = env
-            .storage()
-            .get(&key)
-            .unwrap_or(Ok(0)) // If no value set, assume 0.
-            .unwrap(); // Panic if the value of COUNTER is not u32.
+        let mut count: u32 = env.storage().persistent().get(&key).unwrap_or_default();
 
         // Increment the count.
         count += value;
 
         // Save the count.
-        env.storage().set(&key, &count);
+        env.storage().persistent().set(&key, &count);
 
         // Return the count to the caller.
         count

--- a/docs/basic-tutorials/custom-types.mdx
+++ b/docs/basic-tutorials/custom-types.mdx
@@ -50,6 +50,7 @@ pub struct State {
 
 const STATE: Symbol = Symbol::short("STATE");
 
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -64,20 +65,17 @@ impl IncrementContract {
         state.last_incr = incr;
 
         // Save the count.
-        env.storage().set(&STATE, &state);
+        env.storage().instance().set(&STATE, &state);
 
         // Return the count to the caller.
         state.count
     }
     /// Return the current state.
     pub fn get_state(env: Env) -> State {
-        env.storage()
-            .get(&STATE)
-            .unwrap_or(Ok(State {
-                count: 0,
-                last_incr: 0,
-            })) // If no value set, assume 0.
-            .unwrap() // Panic if the value of COUNTER is not a State.
+        env.storage().instance().get(&STATE).unwrap_or(State {
+            count: 0,
+            last_incr: 0,
+        }) // If no value set, assume 0.
     }
 }
 ```
@@ -142,21 +140,18 @@ Types can also be used as inputs and outputs on contract functions.
 
 ```rust
 pub fn increment(env: Env, incr: u32) -> u32 {
-    let mut state = Self::get_state(env.clone());
-    state.count += incr;
-    state.last_incr = incr;
-    env.storage().set(&STATE, &state);
-    state.count
+        let mut state = Self::get_state(env.clone());
+        state.count += incr;
+        state.last_incr = incr;
+        env.storage().instance().set(&STATE, &state);
+        state.count
 }
 
 pub fn get_state(env: Env) -> State {
-    env.storage()
-        .get(&STATE)
-        .unwrap_or(Ok(State {
-            count: 0,
-            last_incr: 0,
-        })) // If no value set, assume 0.
-        .unwrap() // Panic if the value of COUNTER is not a State.
+    env.storage().instance().get(&STATE).unwrap_or(State {
+        count: 0,
+        last_incr: 0,
+    }) // If no value set, assume 0.
 }
 ```
 

--- a/docs/basic-tutorials/deployer.mdx
+++ b/docs/basic-tutorials/deployer.mdx
@@ -188,6 +188,7 @@ functions that sets a value in the initialization function and allows the value
 to be retrieved from another function.
 
 ```rust title="deployer/contract/src/lib.rs"
+#[contract]
 pub struct Contract;
 
 const KEY: Symbol = Symbol::short("value");
@@ -195,10 +196,10 @@ const KEY: Symbol = Symbol::short("value");
 #[contractimpl]
 impl Contract {
     pub fn init(env: Env, value: u32) {
-        env.storage().set(&KEY, &value);
+        env.storage().instance().set(&KEY, &value);
     }
     pub fn value(env: Env) -> u32 {
-        env.storage().get_unchecked(&KEY).unwrap()
+        env.storage().instance().get(&KEY).unwrap()
     }
 }
 ```
@@ -246,9 +247,16 @@ pass in a single `5u32` argument.
 ```rust
 // Deploy contract using deployer, and include an init function to call.
 let salt = BytesN::from_array(&env, &[0; 32]);
-let init_fn = Symbol::short("init");
-let init_fn_args = (5u32,).into_val(&env);
-let (contract_id, init_result) = client.deploy(&salt, &wasm_hash, &init_fn, &init_fn_args);
+let init_fn = symbol_short!("init");
+let init_fn_args: Vec<Val> = (5u32,).into_val(&env);
+env.mock_all_auths();
+let (contract_id, init_result) = deployer_client.deploy(
+    &deployer_client.address,
+    &wasm_hash,
+    &salt,
+    &init_fn,
+    &init_fn_args,
+);
 assert!(init_result.is_void());
 ```
 

--- a/docs/basic-tutorials/errors.mdx
+++ b/docs/basic-tutorials/errors.mdx
@@ -73,9 +73,10 @@ pub enum Error {
     LimitReached = 1,
 }
 
-const COUNTER: Symbol = Symbol::short("COUNTER");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 const MAX: u32 = 5;
 
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -84,11 +85,7 @@ impl IncrementContract {
     /// if the value is attempted to be incremented past 5.
     pub fn increment(env: Env) -> Result<u32, Error> {
         // Get the current count.
-        let mut count: u32 = env
-            .storage()
-            .get(&COUNTER)
-            .unwrap_or(Ok(0)) // If no value set, assume 0.
-            .unwrap(); // Panic if the value of COUNTER is not u32.
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
         log!(&env, "count: {}", count);
 
         // Increment the count.
@@ -97,7 +94,7 @@ impl IncrementContract {
         // Check if the count exceeds the max.
         if count <= MAX {
             // Save the count.
-            env.storage().set(&COUNTER, &count);
+            env.storage().instance().set(&COUNTER, &count);
 
             // Return the count to the caller.
             Ok(count)

--- a/docs/basic-tutorials/events.mdx
+++ b/docs/basic-tutorials/events.mdx
@@ -43,8 +43,9 @@ test test::test ... ok
 ## Code
 
 ```rust title="events/src/lib.rs"
-const COUNTER: Symbol = Symbol::short("COUNTER");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -52,17 +53,13 @@ impl IncrementContract {
     /// Increment increments an internal counter, and returns the value.
     pub fn increment(env: Env) -> u32 {
         // Get the current count.
-        let mut count: u32 = env
-            .storage()
-            .get(&COUNTER)
-            .unwrap_or(Ok(0)) // If no value set, assume 0.
-            .unwrap(); // Panic if the value of COUNTER is not u32.
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
 
         // Increment the count.
         count += 1;
 
         // Save the count.
-        env.storage().set(&COUNTER, &count);
+        env.storage().instance().set(&COUNTER, &count);
 
         // Publish an event about the increment occuring.
         // The event has two topics:
@@ -70,7 +67,7 @@ impl IncrementContract {
         //   - The "increment" symbol.
         // The event data is the count.
         env.events()
-            .publish((COUNTER, Symbol::short("increment")), count);
+            .publish((COUNTER, symbol_short!("increment")), count);
 
         // Return the count to the caller.
         count

--- a/docs/basic-tutorials/upgrading-contracts.mdx
+++ b/docs/basic-tutorials/upgrading-contracts.mdx
@@ -25,12 +25,13 @@ enum DataKey {
     Admin,
 }
 
+#[contract]
 pub struct UpgradeableContract;
 
 #[contractimpl]
 impl UpgradeableContract {
     pub fn init(e: Env, admin: Address) {
-        e.storage().set(&DataKey::Admin, &admin);
+        e.storage().instance().set(&DataKey::Admin, &admin);
     }
 
     pub fn version() -> u32 {
@@ -38,10 +39,10 @@ impl UpgradeableContract {
     }
 
     pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
-        let admin: Address = e.storage().get_unchecked(&DataKey::Admin).unwrap();
+        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
 
-        e.update_current_contract_wasm(&new_wasm_hash);
+        e.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 }
 
@@ -53,10 +54,10 @@ The upgrade is only possible because the contract calls `e.update_current_contra
 
 ```rust
 pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
-    let admin: Address = e.storage().get_unchecked(&DataKey::Admin).unwrap();
+    let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
     admin.require_auth();
 
-    e.update_current_contract_wasm(&new_wasm_hash);
+    e.deployer().update_current_contract_wasm(new_wasm_hash);
 }
 ```
 

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -316,19 +316,19 @@ impl TryFromVal<Env, DataKey> for RawVal {
 }
 
 fn get_token(e: &Env) -> Address {
-    e.storage().get_unchecked(&DataKey::Token).unwrap()
+    e.storage().instance().get(&DataKey::Token).unwrap()
 }
 
 fn get_token_share(e: &Env) -> Address {
-    e.storage().get_unchecked(&DataKey::TokenShare).unwrap()
+    e.storage().instance().get(&DataKey::TokenShare).unwrap()
 }
 
 fn get_total_shares(e: &Env) -> i128 {
-    e.storage().get_unchecked(&DataKey::TotalShares).unwrap()
+    e.storage().instance().get(&DataKey::TotalShares).unwrap()
 }
 
 fn get_reserve(e: &Env) -> i128 {
-    e.storage().get_unchecked(&DataKey::Reserve).unwrap()
+    e.storage().instance().get(&DataKey::Reserve).unwrap()
 }
 
 fn get_balance(e: &Env, contract: Address) -> i128 {
@@ -344,19 +344,19 @@ fn get_balance_shares(e: &Env) -> i128 {
 }
 
 fn put_token(e: &Env, contract: Address) {
-    e.storage().set(&DataKey::Token, &contract);
+    e.storage().instance().set(&DataKey::Token, &contract);
 }
 
 fn put_token_share(e: &Env, contract: Address) {
-    e.storage().set(&DataKey::TokenShare, &contract);
+    e.storage().instance().set(&DataKey::TokenShare, &contract);
 }
 
 fn put_total_shares(e: &Env, amount: i128) {
-    e.storage().set(&DataKey::TotalShares, &amount)
+    e.storage().instance().set(&DataKey::TotalShares, &amount)
 }
 
 fn put_reserve(e: &Env, amount: i128) {
-    e.storage().set(&DataKey::Reserve, &amount)
+    e.storage().instance().set(&DataKey::Reserve, &amount)
 }
 
 fn burn_shares(e: &Env, amount: i128) {

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-advanced-concepts.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-advanced-concepts.mdx
@@ -538,15 +538,15 @@ In contrast to Solidity's global variables, Soroban relies on passing an [`Env`]
 
 The `Env` provides access to information about the currently executing contract, who invoked it, contract data, functions for signing, hashing, etc.
 
-For instance, you would use `env.storage().get(key)` to access a target value from the contract's [storage](https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html).
+For instance, you would use `env.storage().persistent().get(key)` to access a `persistent` target value from the contract's [storage](https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html). Read more about the different storage types [here](../persisting-data.mdx).
 
 - `env.storage()` is used to get a struct for accessing and updating contract data that has been stored.
-- Used as `env.storage().get()` or `env.storage().set()`.
+- Used as `env.storage().persistent().get()` or `env.persistent().storage().set()`.
 - Additionally, we utilize the `clone()` method, a prevalent trait in Rust that allows for the explicit duplication of an object.
 
 See the example below for implementations of `env.storage()` and `clone()`
 
-- `env.storage().set()`
+- `env.storage().persistent().set()`
 
 ```rust
 use soroban_sdk::{Env, Symbol};
@@ -554,17 +554,17 @@ use soroban_sdk::{Env, Symbol};
     pub fn set_storage(env: Env) {
         let key = Symbol::short("key");
         let value = Symbol::short("value");
-        env.storage().set(&key, &value);
+        env.storage().persistent().set(&key, &value);
 }
 ```
 
-- `env.storage().get()`
+- `env.storage().persistent().get()`
 
 ```rust
 use soroban_sdk::{Env};
 
     pub fn get_storage(env: Env) -> value {
-        env.storage().get(&key);
+        env.storage().persistent().get(&key);
 }
 ```
 

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -431,21 +431,17 @@ pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
-    /// increment increments an internal counter, and returns the value.
+    /// Increment increments an internal counter, and returns the value.
     pub fn increment(env: Env) -> u32 {
         // Get the current count.
-        let mut count: u32 = env
-            .storage()
-            .get(&COUNTER)
-            .unwrap_or(Ok(0)) // If no value set, assume 0.
-            .unwrap(); // Extract the actual value from the `Ok` wrapper
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
         log!(&env, "count: {}", count);
 
         // Increment the count.
         count += 1;
 
         // Save the count.
-        env.storage().set(&COUNTER, &count);
+        env.storage().instance().set(&COUNTER, &count);
 
         // Return the count to the caller.
         count
@@ -453,7 +449,7 @@ impl IncrementContract {
 
     /// get_count returns the current value of the counter.
     pub fn get_count(env: Env) -> u32 {
-        env.storage().get(&COUNTER).unwrap_or(Ok(0)).unwrap()
+        env.storage().instance().get(&COUNTER).unwrap_or(0)
     }
 }
 ```
@@ -481,6 +477,7 @@ const COUNTER: Symbol = Symbol::short("COUNTER");
 This creates a new `Symbol` value with the string "COUNTER". The constant `COUNTER` is then used as a key to identify the count value stored in the contract `storage`.
 
 ```rust
+#[contract]
 pub struct IncrementContract;
 ```
 
@@ -502,10 +499,10 @@ pub fn increment(env: Env) -> u32 {}
 This is a public function called `increment` that takes an `Env` struct as an argument and returns a `u32`. `Env` is the environment the contract is executing in, and `u32` is the type of value returned by the function.
 
 ```rust
-let mut count: u32 = env.storage().get(&COUNTER).unwrap_or(Ok(0)).unwrap(); // If no value set, assume 0.
+let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0)); // If no value set, assume 0.
 ```
 
-In this line of code, a mutable variable named `count` of type unsigned 32-bit integer (`u32`) is being created. The storage environment is accessed using `env.storage()`, and the value associated with the key `COUNTER` is retrieved using the `get` method. If there is no value set for the key `COUNTER`, a default value of 0 is used. Finally, the `unwrap()` method is called to extract the actual value from the `Ok` wrapper, which is then assigned to the `count` variable.
+In this line of code, a mutable variable named `count` of type unsigned 32-bit integer (`u32`) is being created. The storage environment is accessed using `env.storage()`, and the value associated with the key `COUNTER` is retrieved using the `get` method. If there is no value set for the key `COUNTER`, a default value of 0 is used.
 
 ```rust
 log!(&env, "count: {}", count);
@@ -520,7 +517,7 @@ count += 1;
 This increments the count by 1.
 
 ```rust
-env.storage().set(&COUNTER, &count);
+env.storage().instance().set(&COUNTER, &count);
 ```
 
 This saves the updated count back to the contract storage using the `set` method on the storage object.
@@ -538,7 +535,7 @@ pub fn get_count(env: Env) -> u32 {}
 This is a public function called `get_count` that takes an `Env` struct as an argument and returns a `u32`. Once more we see the `Env` which is the environment the contract is executing in, and `u32` as the type of the value returned by the function.
 
 ```rust
-env.storage().get(&COUNTER).unwrap_or(Ok(0)).unwrap()
+env.storage().instance().get(&COUNTER).unwrap_or(0)
 ```
 
 This is a repeat of the code we saw earlier, which retrieves the value associated with the key `COUNTER` from the contract storage. If there is no value set for the key `COUNTER`, a default value of 0 is used. Finally, the `unwrap()` method is called to extract the actual value from the `Ok` wrapper, which is then returned to the caller of the function.

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -49,15 +49,19 @@ pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
+    /// Increment increments an internal counter, and returns the value.
     pub fn increment(env: Env) -> u32 {
-        let mut count: u32 = env
-            .storage()
-            .get(COUNTER)
-            .unwrap_or(Ok(0)) // If no value set, assume 0.
-            .unwrap(); // Panic if the value of COUNTER is not u32.
+        // Get the current count.
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
         log!(&env, "count: {}", count);
+
+        // Increment the count.
         count += 1;
-        env.storage().set(COUNTER, count);
+
+        // Save the count.
+        env.storage().instance().set(&COUNTER, &count);
+
+        // Return the count to the caller.
         count
     }
 }

--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -176,6 +176,19 @@ pub trait Contract {
 }
 ```
 
+:::caution CAUTION WHEN MODIFYING ALLOWANCES
+
+The `approve` function overwrites the previous value with `amount`, so it is
+possible for the previous allowance to be spent in an earlier transaction before
+`amount` is written in a later transaction. The result of this is that `spender`
+can spend more than intended. This issue can be avoided by first setting the
+allowance to 0, verifying that the spender didn't spend any portion of the
+previous allowance, and then setting the allowance to the new desired amount.
+You can read more about this issue here -
+https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729.
+
+:::
+
 ### Metadata
 
 Another requirement for complying with the token interface is to write the


### PR DESCRIPTION
The second commit attempts to fix all references to storage that doesn't use the new state expiration interface. This is still a WIP because the changes that are left are in-depth tutorials, and we need the state expirations docs so we can point to the different kinds of storage that developers can use.