### PR TITLE
More detailed state expiration docs

### DIFF
--- a/docs/fundamentals-and-concepts/persisting-data.mdx
+++ b/docs/fundamentals-and-concepts/persisting-data.mdx
@@ -8,7 +8,7 @@ description: Storing and accessing contract data.
 
 Contracts can access ledger entries of type `CONTRACT_DATA`. Host functions are provided to probe, read, write, and delete `CONTRACT_DATA` ledger entries.
 
-Each `CONTRACT_DATA` ledger entry is keyed in the ledger by the contract ID that owns it, as well as a single user-chosen value, of the standard value type. This means that the user-chosen key may be a simple value such as a symbol, number or binary blob, or it may be a more complex structured value like a vector or map with multiple sub-values.
+Each `CONTRACT_DATA` ledger entry is keyed in the ledger by the contract ID that owns it, its storage type (`Persistent`, `Temporary`, `Instance`) as well as a single user-chosen value, of the standard value type. This means that the user-chosen key may be a simple value such as a symbol, number or binary blob, or it may be a more complex structured value like a vector or map with multiple sub-values.
 
 Each `CONTRACT_DATA` ledger entry also holds (in addition to its key) a single value associated with the key. Again, this value may be simple like a symbol or number, or may be complex like a vector or map with many sub-values.
 
@@ -18,6 +18,8 @@ No serialization or deserialization is required in contract code when accessing 
 
 Contracts are only allowed to read and write `CONTRACT_DATA` ledger entries owned by the contract: those keyed by the same contract ID as the contract performing the read or write. Attempting to access other `CONTRACT_DATA` ledger entries will cause a transaction to fail.
 
+There is no access control for lifetime bump operations. Any user may invoke `BumpFootprintExpirationOp` on any LedgerEntry.
+
 ## Granularity
 
 A `CONTRACT_DATA` ledger entry is read or written from the ledger in its entirety; there is no way to read or write "only a part" of a `CONTRACT_DATA` ledger entry. There is also a fixed overhead cost to accessing any `CONTRACT_DATA` ledger entry. Contracts are therefore responsible for dividing logically "large" data structures into "pieces" with an appropriate size granularity, to use for reading and writing. If pieces are too large there may be unnecessary costs paid for reading and writing unused data, as well as unnecessary contention in parallel execution; but if pieces are too small there may be unnecessary costs paid for the fixed overhead of each entry.
@@ -25,3 +27,63 @@ A `CONTRACT_DATA` ledger entry is read or written from the ledger in its entiret
 ## Footprints and parallel contention
 
 Contracts are only allowed to access ledger entries specified in the footprint of their transaction. Transactions with overlapping footprints are said to contend, and will only execute sequentially with respect to one another, on a single thread. Transactions with non-overlapping footprints may execute in parallel. This means that a finer granularity of `CONTRACT_DATA` ledger entries may reduce artificial contention among transactions using a contract, and thereby increase parallelism.
+
+## Contract Data Best Practices
+
+### Account State vs. Shared State
+
+While there is no distinction between "account" state and "shared" state at the protocol level, it can be helpful to think of data in these terms when deciding what storage type and lifetime bump strategy
+to use for a given use case. As a guideline, account and shared state can be described as follows:
+
+- Most contract state can either be associated with a specific account or shared between multiple stakeholders (“public good”)
+  - Account specific state
+    - Balances, positions, allowances, etc.
+  - Shared state
+    - Admin entry, pool values, etc.
+- There are two subcategories of shared state
+  - "Global" state shared by all contract users
+    - Contract instance, contract wasm, or a global admin
+  - State shared by only a specific subset of users
+    - AMM pool values In an AMM monolith contract (Uniswap V4 style)
+- Note: Sometimes account and shared state can merge when the contract scope is small
+  - I.e. smart wallet or a single nft, where a new contract instance is generated for each account
+
+### Owned Contracts vs. Autonomous Contracts
+
+In addition to the types of state, it is also helpful to consider the type of contract instance being used. Again, these types are not enforced at the protocol level, but can be helpful.
+
+- Owned contracts
+  - Contract instances that have a clear owner
+    - A smart wallet or a single nft, where a new contract instance is generated for each account
+    - Custom reserve backed assets (USDC, etc)
+- Autonomous contracts
+  - Contract instance that have not clear owner, or have a decentralized group of owners
+    - Most DeFi protocols, especially non-upgradable ones
+
+### Best Practices
+
+- Prefer `Temporary` over `Persistent` and `Instance` storage
+  - Anything that can have a timeout should be `Temporary` with expiration set to the timeout. Maximum timeout/expiration is currently 1 year
+  - Ideally, `Temporary` entries should be associated with an absolute ledger boundary and thus never bumped
+    - Example: Soroban Auth signatures have an absolute expiration ledger, so nonces can be stored in `Temporary` entries without security risks
+    - Example: SAC allowance that lives only until a given ledger (so that some old allowance signature can not be used in the future if not exhausted)
+- All global state that cannot be `Temporary` should be in `Instance` storage
+  - This guarantees that the lifetime of the contract instance and all relevant globals are tied together
+  - Since global state is used often, this ensures that global state will never need to be restored, leading to cheaper and more efficient contract invocations
+- Autonomous contracts should bump any shared state touched by an invocation via the `bump()` host function
+  - Given that these contracts have no owners, leaving lifetime bumps to benevolent clients might lead to a “tragedy of the commons” situation
+  - Most users do not bump the lifetime because it is not required, but still benefit from the benevolent client who does bump the lifetime
+- Owners of owned contracts should subsidize shared state lifetime extension fees by manually submitting bump operations
+  - Owners should keep track of expiration ledgers for all shared state
+  - This could be implemented via something like a cron job where a `BumpFootprintExpirationOp` for all relevant shared state is submitted periodically (i.e. once a month)
+  - Alternatively, this could also be implemented via an admin smart contract function routinely called by the owner
+- Clients (Wallets/Dapps) should identify the state that relates to their respective account, present expiration info to the users, and suggest lifetime bumps when necessary
+- Lifetime extensions should never be relied on for functionality or safety
+  - Unsafe example: An entry must be permanent, but instead of using `Persistent` storage, a contract uses `Temporary` storage but will continually bump the entry so it never expires
+    - Because there is no automatic lifetime extension interface, and every bump must come from either a smart contract invocation or `BumpFootprintExpirationOp`, it must be assumed that an entry can always expire
+    - Lifetime extension fees are variable, and it may become too expensive to bump pseudo “persistent” `Temporary` entries if fees increase unexpectedly
+    - If the rent bump process is automated (i.e. a cron job) the account automatically sending `BumpFootprintExpirationOps` may run out of funds unexpectedly should lifetime extension fees increase, causing the `Temporary` entry to expire and be permanently deleted
+- Entry expiration should never be relied on for functionality or safety
+  - Unsafe example: a nonce should expire in 7 days, so a contract creates a `Temporary` entry and bumps the lifetime to 7 days with no other lifetime enforcement in place.
+  - Anyone can submit a rent bump operation on any entry without authorization, meaning that the nonce can have its lifetime extended indefinitely by any user
+  - If an entry needs to be invalidated after a certain time period, this must be implemented manually by the contract

--- a/docs/getting-started/state-expiration.mdx
+++ b/docs/getting-started/state-expiration.mdx
@@ -4,6 +4,35 @@ title: 8. State Expiration
 description: State Expiration Semantics
 ---
 
+# Terms and Semantics
+
+## Expiration Ledger
+
+Each `ContractData` and `ContractCode` entry has an `expirationLedger` field stored in its `LedgerEntry`.
+The entry is considered expired when `current_ledger > expirationLedger`.
+
+## Lifetime
+
+An entry's lifetime is defined as how many ledgers remain until the entry expires.
+For example, if the current ledger is 5 and an entry's expiration ledger is 15, then
+the entry's lifetime is 10 ledgers.
+
+## Minimum Lifetime
+
+For each entry type, there is a minimum lifetime that the entry must have when being created
+or updated. This lifetime minimum is enforced automatically at the protocol level. This minimum
+is a network parameter and defaults to 16 ledgers for `Temporary` entries and 4,096 ledgers for
+`Persistent` and `Instance` entries.
+
+## Maximum Lifetime
+
+On any given ledger, an entry's lifetime can be extended up to the maximum lifetime. This is a
+network parameter and defaults to 1 year worth of ledgers. This maximum lifetime is not enforced
+based on when an entry was created, but based on the current ledger. For example, if an entry is
+created on January 1st, 2024, its lifetime could initially be bumped up to January 1st, 2025.
+After this initial lifetime bump, if the entry received another lifetime bump later on January 10th, 2024,
+the lifetime could be extended up to January 10th, 2025.
+
 # Operations
 
 ## BumpFootprintExpirationOp

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -85,15 +85,25 @@ Short `Symbol`s up to 9 characters long can be pre-computed at compile time usin
 const COUNTER: Symbol = Symbol::short("COUNTER");
 ```
 
+### Types of Contract data
+
+Contract data is made up of three different types: `Persistent`, `Temporary`, and `Instance`. All contract data has a "lifetime" that must be periodically bumped. If an entry's
+lifetime is not periodically bumped, the entry will eventually reach the end of its lifetime and "expire". Each type of storage functions similarly, but have different fees and expiration behavior. Whenever a
+`Temporary` entry expires, it is deleted from the ledger and is permanently inaccessible. Whenever a `Persistent` or `Instance` entry expires, it is inaccessible, but can be
+"restored" and used again via the [`RestoreFootprintOp`]. As a general rule, `Temporary` storage should only be used for data that can be easily recreated or is only valid for a period
+of time, where `Persistent` or `Instance` storage should be used for data that can not be recreated and should kept permanently, such as a user's token balance. For more information
+about the different storage types, see [Contract Data Type Descriptions](#Contract-Data-Type-Descriptions).
+
 ### Contract Data Access
 
-The `Env` `data()` function is used to retrieve access and update a counter. The executing contract is the only contract that can query or modify contract data that it has stored. The data stored is viewable on ledger anywhere the ledger is viewable, but contracts executing within the Soroban environment are restricted to their own data.
+The `Env.storage()` function is used to retrieve access and update a counter. The executing contract is the only contract that can query or modify contract data that it has stored. The data stored is viewable on ledger anywhere the ledger is viewable, but contracts executing within the Soroban environment are restricted to their own data.
 
 The `get()` function gets the current value associated with the counter key.
 
 ```rust
 let mut count: u32 = env
     .storage()
+    .instance()
     .get(COUNTER)
     .unwrap_or(Ok(0)) // If no value set, assume 0.
     .unwrap(); // Panic if the value of COUNTER is not u32.
@@ -106,8 +116,35 @@ Values stored as contract data and retrieved are transmitted from the environmen
 The `set()` function stores the new count value against the key, replacing the existing value.
 
 ```rust
-env.storage().set(COUNTER, count);
+env.storage().instance().set(COUNTER, count);
 ```
+
+To access a given type of storage, use `Env.storage().persistent()`, `Env.storage().temporary()`, and `Env.storage().instance()`.
+Each storage type is in a separate key space. To demonstrate this, see the code snippet below:
+
+```rust
+const EXAMPLE_KEY: Symbol = Symbol::short("KEY");
+env.storage().persistent().set(EXAMPLE_KEY, 1);
+env.storage().temporary().set(EXAMPLE_KEY, 2);
+
+env.storage().persistent().get(EXAMPLE_KEY); // Returns Ok(1)
+env.storage().temporary().get(EXAMPLE_KEY); // Returns Ok(2)
+```
+
+
+### Managing Contract Data Lifetimes
+
+The `Env.storage().storage_type().bump()` function is used to extend a contract data entry's lifetime inside a smart contract function. The `bump()` function is a conditional lifetime bump which
+extends an entry's lifetime up to a given length of time, measured in ledgers.
+
+```rust
+env.storage().instance().bump(COUNTER, 100);
+```
+
+This call to `bump()` ensures that the current lifetime of the `COUNTER` `Instance` entry is at least 100 ledgers. If this is called and the `COUNTER` `Instance` entry has a current lifetime of 50 ledgers,
+the lifetime will be extended up to 100 ledgers. If this is called and the `COUNTER` `Instance` entry has a current lifetime of 150 ledgers, the lifetime will not be extended and the `bump()` call is a no-op.
+
+In addition to contract defined lifetime extensions using the `bump()` function, a contract data entry's lifetime can be extended via the [`BumpFootprintExpirationOp`] operation.
 
 ## Tests
 
@@ -197,6 +234,32 @@ soroban contract invoke \
 Footprint: {"readOnly":[{"contractData":{"contractId":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],"key":{"static":"ledgerKeyContractCode"}}}],"readWrite":[{"contractData":{"contractId":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],"key":{"symbol":[67,79,85,78,84,69,82]}}}]}
 ```
 
+### Contract Data Type Descriptions
+
+The general usage and interface is identical for all storage types. They differ only in fees and expiration behavior as follows:
+
+- `Temporary`
+    - Cheapest fees.
+    - Permanently deleted on expiration, cannot be restored.
+    - Suitable for time bounded data (i.e. price oracles, signatures, etc.) and easily recreateable data.
+    - Unlimited amount of storage.
+- `Instance`
+    - Most expensive fees (same price as `Persistent` storage).
+    - Recoverable after expiration, can be restored using the [`RestoreFootprintOp`] operation.
+    - Shares the same lifetime as the contract instance. If the contract instance has not expired, instance data is guaranteed to be accessible and not expired.
+    - Limited amount of storage available.
+    - Suitable for "shared" contract state that cannot be `Temporary` (i.e. admin accounts, contract metadata, etc.).
+- `Persistent`
+    - Most expensive fees (same price as `Instance` storage).
+    - Recoverable after expiration, can be restored using the [`RestoreFootprintOp`] operation.
+    - Does not share the same lifetime as the contract instance. If the contract instance is not expired, `Persistent` data may be expired and need to be restored before invoking the contract.
+    - Unlimited amount of storage.
+    - Suitable for user data that cannot be `Temporary` (i.e. balances).
+
+For more detailed guidelines on how to use contract data, see [`Contract Data Best Practices`].
+
+### Contract Data Best Practices
+
 :::info
 
 Soroban is a pre-release and at this time outputs footprints in an unstable JSON format.
@@ -214,3 +277,6 @@ soroban contract read --id 1 --key COUNTER
 ```
 
 [`soroban-cli`]: ../getting-started/setup#install-the-soroban-cli
+[`BumpFootprintExpirationOp`]: ../getting-started/state-expiration#BumpFootprintExpirationOp
+[`RestoreFootprintOp`]: ../getting-started/state-expiration#RestoreFootprintOp
+[`Contract Data Best Practices`]: ../fundamentals-and-concepts/persisting-data.mdx#contract-data-best-practices


### PR DESCRIPTION
Adds a high level storage type overview to `storing-data.mdx` and a more detailed state-expiration user guide to `persisting-data.mdx`. Note that I couldn't get the `.mdx` files to render properly in my editor, so some of my syntax or links may be slightly off.