### PR TITLE
add #[contract] and symbol_short

### DIFF
--- a/docs/advanced-tutorials/atomic-swap.mdx
+++ b/docs/advanced-tutorials/atomic-swap.mdx
@@ -46,6 +46,7 @@ test test::test_atomic_swap ... ok
 ## Code
 
 ```rust title="atomic_swap/src/lib.rs"
+#[contract]
 pub struct AtomicSwapContract;
 
 #[contractimpl]

--- a/docs/advanced-tutorials/tokens.mdx
+++ b/docs/advanced-tutorials/tokens.mdx
@@ -84,7 +84,7 @@ pub use crate::contract::TokenClient;
 
 ```rust title="token/src/admin.rs"
 use crate::storage_types::DataKey;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, symbol_short};
 
 pub fn has_administrator(e: &Env) -> bool {
     let key = DataKey::Admin;
@@ -417,7 +417,7 @@ impl TokenTrait for Token {
 <TabItem value="event">
 
 ```rust title="token/src/event.rs"
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, Env, Symbol, symbol_short};
 
 pub(crate) fn approve(e: &Env, from: Address, to: Address, amount: i128, expiration_ledger: u32) {
     let topics = (Symbol::new(e, "approve"), from, to);
@@ -425,17 +425,17 @@ pub(crate) fn approve(e: &Env, from: Address, to: Address, amount: i128, expirat
 }
 
 pub(crate) fn transfer(e: &Env, from: Address, to: Address, amount: i128) {
-    let topics = (Symbol::short("transfer"), from, to);
+    let topics = (symbol_short!("transfer"), from, to);
     e.events().publish(topics, amount);
 }
 
 pub(crate) fn mint(e: &Env, admin: Address, to: Address, amount: i128) {
-    let topics = (Symbol::short("mint"), admin, to);
+    let topics = (symbol_short!("mint"), admin, to);
     e.events().publish(topics, amount);
 }
 
 pub(crate) fn clawback(e: &Env, admin: Address, from: Address, amount: i128) {
-    let topics = (Symbol::short("clawback"), admin, from);
+    let topics = (symbol_short!("clawback"), admin, from);
     e.events().publish(topics, amount);
 }
 
@@ -445,12 +445,12 @@ pub(crate) fn set_authorized(e: &Env, admin: Address, id: Address, authorize: bo
 }
 
 pub(crate) fn set_admin(e: &Env, admin: Address, new_admin: Address) {
-    let topics = (Symbol::short("set_admin"), admin);
+    let topics = (symbol_short!("set_admin"), admin);
     e.events().publish(topics, new_admin);
 }
 
 pub(crate) fn burn(e: &Env, from: Address, amount: i128) {
-    let topics = (Symbol::short("burn"), from);
+    let topics = (symbol_short!("burn"), from);
     e.events().publish(topics, amount);
 }
 ```
@@ -556,7 +556,7 @@ event whenever the token is minted:
 
 ```rust
 pub(crate) fn mint(e: &Env, admin: Address, to: Address, amount: i128) {
-    let topics = (Symbol::short("mint"), admin, to);
+    let topics = (symbol_short!("mint"), admin, to);
     e.events().publish(topics, amount);
 }
 ```

--- a/docs/basic-tutorials/alloc.mdx
+++ b/docs/basic-tutorials/alloc.mdx
@@ -59,6 +59,7 @@ use soroban_sdk::{contractimpl, Env};
 
 extern crate alloc;
 
+#[contract]
 pub struct AllocContract;
 
 #[contractimpl]

--- a/docs/basic-tutorials/auth.mdx
+++ b/docs/basic-tutorials/auth.mdx
@@ -196,7 +196,7 @@ fn test() {
             // Identifier of the called contract
             contract_id.clone(),
             // Name of the called function
-            Symbol::short("increment"),
+            symbol_short!("increment"),
             // Arguments used to call `increment` (converted to the env-managed vector via `into_val`)
             (user_1.clone(), 5_u32).into_val(&env)
         )]
@@ -270,7 +270,7 @@ assert_eq!(
         // Identifier of the called contract
         contract_id.clone(),
         // Name of the called function
-        Symbol::short("increment"),
+        symbol_short!("increment"),
         // Arguments used to call `increment` (converted to the env-managed vector via `into_val`)
         (user_1.clone(), 5_u32).into_val(&env)
     )]

--- a/docs/basic-tutorials/cross-contract-call.mdx
+++ b/docs/basic-tutorials/cross-contract-call.mdx
@@ -53,6 +53,7 @@ test test::test ... ok
 ## Code
 
 ```rust title="cross_contract/contract_a/src/lib.rs"
+#[contract]
 pub struct ContractA;
 
 #[contractimpl]
@@ -70,6 +71,7 @@ mod contract_a {
     );
 }
 
+#[contract]
 pub struct ContractB;
 
 #[contractimpl]
@@ -110,6 +112,7 @@ The contract to be called is Contract A. It is a simple contract that accepts
 `x` and `y` parameters, adds them together and returns the result.
 
 ```rust title="cross_contract/contract_a/src/lib.rs"
+#[contract]
 pub struct ContractA;
 
 #[contractimpl]
@@ -150,6 +153,7 @@ mod contract_a {
     );
 }
 
+#[contract]
 pub struct ContractB;
 
 #[contractimpl]

--- a/docs/basic-tutorials/custom-types.mdx
+++ b/docs/basic-tutorials/custom-types.mdx
@@ -48,7 +48,7 @@ pub struct State {
     pub last_incr: u32,
 }
 
-const STATE: Symbol = Symbol::short("STATE");
+const STATE: Symbol = symbol_short!("STATE");
 
 #[contract]
 pub struct IncrementContract;

--- a/docs/basic-tutorials/deployer.mdx
+++ b/docs/basic-tutorials/deployer.mdx
@@ -49,6 +49,7 @@ test test::test ... ok
 ## Code
 
 ```rust title="deployer/deployer/src/lib.rs"
+#[contract]
 pub struct Deployer;
 
 #[contractimpl]
@@ -160,7 +161,7 @@ fn test() {
 
     // Deploy contract using deployer, and include an init function to call.
     let salt = BytesN::from_array(&env, &[0; 32]);
-    let init_fn = Symbol::short("init");
+    let init_fn = symbol_short!("init");
     let init_fn_args = (5u32,).into_val(&env);
     let (contract_id, init_result) = client.deploy(&salt, &wasm_hash, &init_fn, &init_fn_args);
     assert!(init_result.is_void());
@@ -191,7 +192,7 @@ to be retrieved from another function.
 #[contract]
 pub struct Contract;
 
-const KEY: Symbol = Symbol::short("value");
+const KEY: Symbol = symbol_short!("value");
 
 #[contractimpl]
 impl Contract {

--- a/docs/basic-tutorials/events.mdx
+++ b/docs/basic-tutorials/events.mdx
@@ -99,7 +99,7 @@ Topics are conveniently defined using a tuple. In the sample code two topics of
 `Symbol` type are used.
 
 ```rust
-env.events().publish((COUNTER, Symbol::short("increment")), ...);
+env.events().publish((COUNTER, symbol_short!("increment")), ...);
 ```
 
 :::tip
@@ -128,7 +128,7 @@ limit) and running over the resource budget (TBD). Once successfully published,
 the new event will be available to applications consuming the events.
 
 ```rust
-env.events().publish((COUNTER, Symbol::short("increment")), count);
+env.events().publish((COUNTER, symbol_short!("increment")), count);
 ```
 
 :::caution
@@ -159,17 +159,17 @@ fn test() {
             &env,
             (
                 contract_id.clone(),
-                (Symbol::short("COUNTER"), Symbol::short("increment")).into_val(&env),
+                (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
                 1u32.into_val(&env)
             ),
             (
                 contract_id.clone(),
-                (Symbol::short("COUNTER"), Symbol::short("increment")).into_val(&env),
+                (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
                 2u32.into_val(&env)
             ),
             (
                 contract_id,
-                (Symbol::short("COUNTER"), Symbol::short("increment")).into_val(&env),
+                (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
                 3u32.into_val(&env)
             ),
         ]
@@ -215,7 +215,7 @@ assert_eq!(
         &env,
         (
             contract_id.clone(),
-            (Symbol::short("COUNTER"), Symbol::short("increment")).into_val(&env),
+            (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
             1u32.into_val(&env)
         ),
         // ...

--- a/docs/basic-tutorials/logging.mdx
+++ b/docs/basic-tutorials/logging.mdx
@@ -74,6 +74,7 @@ debug-assertions = true
 #![no_std]
 use soroban_sdk::{contractimpl, log, Env, Symbol};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]
@@ -163,7 +164,7 @@ fn test() {
     let contract_id = env.register_contract(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
-    client.hello(&Symbol::short("Dev"));
+    client.hello(&symbol_short!("Dev"));
 
     let logs = env.logger().all();
     assert_eq!(logs, std::vec!["Hello Symbol(Dev)"]);
@@ -201,7 +202,7 @@ type with `Client` appended. For example, in our contract the contract type is
 
 ```rust
 let client = HelloContractClient::new(&env, &contract_id);
-let words = client.hello(&Symbol::short("Dev"));
+let words = client.hello(&symbol_short!("Dev"));
 ```
 
 Logs are available in tests via the environment.

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -157,7 +157,7 @@ Soroban enables users to leverage the power of Rust's testing framework to write
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{vec, Env, Symbol};
+use soroban_sdk::{vec, Env, Symbol, symbol_short};
 
 #[test]
 fn test() {
@@ -165,10 +165,10 @@ fn test() {
     let contract_id = env.register_contract(None, HelloContract);
     let client = HelloContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&Symbol::short("Dev"));
+    let words = client.hello(&symbol_short!("Dev"));
     assert_eq!(
         words,
-        vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]
+        vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
     );
 }
 ```
@@ -535,13 +535,13 @@ fn test() {
             (
                 user1.clone(),
                 vault.address.clone(),
-                Symbol::short("deposit"),
+                symbol_short!("deposit"),
                 (&user1, 100_i128).into_val(&e)
             ),
             (
                 user1.clone(),
                 token.address.clone(),
-                Symbol::short("transfer"),
+                symbol_short!("transfer"),
                 (&user1, &vault.address, 100_i128).into_val(&e)
             ),
         ]
@@ -559,13 +559,13 @@ fn test() {
             (
                 user1.clone(),
                 vault.address.clone(),
-                Symbol::short("withdraw"),
+                symbol_short!("withdraw"),
                 (&user1, 100_i128).into_val(&e)
             ),
             (
                 user1.clone(),
                 token_share.address.clone(),
-                Symbol::short("transfer"),
+                symbol_short!("transfer"),
                 (&user1, &vault.address, 100_i128).into_val(&e)
             ),
         ]
@@ -655,6 +655,7 @@ fn check_nonnegative_amount(amount: i128) {
     }
 }
 
+#[contract]
 pub struct Token;
 
 #[contractimpl]

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-advanced-concepts.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-advanced-concepts.mdx
@@ -148,6 +148,7 @@ use soroban_sdk::{contractimpl, Env};
 
 extern crate alloc;
 
+#[contract]
 pub struct AllocContract;
 
 #[contractimpl]
@@ -181,7 +182,7 @@ Below is a function from the [`event.rs`](https://github.com/stellar/soroban-exa
 use soroban_sdk::{Address, Env, Symbol};
 ...
 pub(crate) fn mint(e: &Env, admin: Address, to: Address, amount: i128) {
-    let topics = (Symbol::short("mint"), admin, to);
+    let topics = (symbol_short!("mint"), admin, to);
     e.events().publish(topics, amount);
 }
 ```
@@ -235,6 +236,7 @@ fn mint(e: Env, to: Address, amount: i128);
 }
 
 // struct logic
+#[contract]
 pub struct Token;
 
 // impl logic
@@ -321,6 +323,7 @@ pub trait MathContract {
     fn add(&self, env: Env, a: u32, b: u32) -> u32;
 }
 
+#[contract]
 pub struct Adder;
 
 impl MathContract for Adder {
@@ -552,8 +555,8 @@ See the example below for implementations of `env.storage()` and `clone()`
 use soroban_sdk::{Env, Symbol};
 
     pub fn set_storage(env: Env) {
-        let key = Symbol::short("key");
-        let value = Symbol::short("value");
+        let key = symbol_short!("key");
+        let value = symbol_short!("value");
         env.storage().persistent().set(&key, &value);
 }
 ```
@@ -647,6 +650,7 @@ Here is an example of a smart contract that illustrates how contracts can be ret
 #![no_std]
 use soroban_sdk::{contractimpl, log, Address, Env, Symbol};
 
+#[contract]
 pub struct SimpleContract;
 
 #[contractimpl]
@@ -736,6 +740,7 @@ mod outer {
     }
 }
 
+#[contract]
 pub struct NewContract;
  trait OuterTrait {
     fn get_all_fields() -> u32;
@@ -793,6 +798,7 @@ Here is an example of a smart contract that illustrates how time-based variables
 #![no_std]
 use soroban_sdk::{contractimpl, Address, Env};
 
+#[contract]
 pub struct SimpleContract;
 
 #[contractimpl]
@@ -868,6 +874,7 @@ Here is an example of a smart contract that illustrates how authorization is han
 #![no_std]
 use soroban_sdk::{contractimpl, testutils::Address as _, Address, Symbol, Env, IntoVal};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -138,7 +138,7 @@ The [Soroban Rust SDK](https://docs.rs/soroban-sdk/latest/soroban_sdk/index.html
 
   - (`Symbol::new`): small efficient strings up to 32 characters in length and requires an env to be passed in
 
-  - (`Symbol::short`) small efficient strings up to 9 characters in length
+  - (`symbol_short!`) small efficient strings up to 9 characters in length
 
   Both are limited to the characters `a-zA-Z0-9_` and are encoded into 64-bit integers.
 
@@ -168,7 +168,7 @@ let msg: &str = "Hello";
 String::from_slice(&env, msg)
 
 // Symbols (short and new)
-let symbol_short = Symbol::short("Sample"); // up to 9 chars
+let symbol_short = symbol_short!("Sample"); // up to 9 chars
 // env is &Env
 let symbol_new = Symbol::new(env, "SampleSymbolExpression");
 
@@ -304,7 +304,7 @@ Functions that are publicly accessible in the implementation are invocable by ot
 #[contractimpl]
 impl HelloContract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+        vec![&env, symbol_short!("Hello"), to]
     }
 }
 ```
@@ -425,8 +425,9 @@ In this section, we'll create a Rust program that simulates the functionality of
 #![no_std]
 use soroban_sdk::{contractimpl, log, Env, Symbol};
 
-const COUNTER: Symbol = Symbol::short("COUNTER");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -471,7 +472,7 @@ use soroban_sdk::{contractimpl, log, Env, Symbol};
 This code imports necessary items from the Soroban Rust SDK for writing a smart contract. The `contractimpl` [macro](https://doc.rust-lang.org/book/ch19-06-macros.html) is used to implement the smart contract, while the `log` macro is used for logging messages. The `Env` struct represents the environment the contract is executing in, and the `Symbol` type is a small, efficient string type.
 
 ```rust
-const COUNTER: Symbol = Symbol::short("COUNTER");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 ```
 
 This creates a new `Symbol` value with the string "COUNTER". The constant `COUNTER` is then used as a key to identify the count value stored in the contract `storage`.

--- a/docs/getting-started/deploy-to-a-local-network.mdx
+++ b/docs/getting-started/deploy-to-a-local-network.mdx
@@ -25,7 +25,7 @@ To run a local standalone network with the Stellar Quickstart Docker image, run 
 docker run --rm -it \
   -p 8000:8000 \
   --name stellar \
-  stellar/quickstart:soroban-dev@sha256:57e8ab498bfa14c65595fbb01cb94b1cdee9637ef2e6634e59d54f6958c05bdb \
+  stellar/quickstart:soroban-dev@sha256:ed57f7a7683e3568ae401f5c6e93341a9f77d8ad41191bf752944d7898981e0c \
   --standalone \
   --enable-soroban-rpc
 ```

--- a/docs/getting-started/deploy-to-futurenet.mdx
+++ b/docs/getting-started/deploy-to-futurenet.mdx
@@ -47,7 +47,7 @@ To run your own soroban-rpc locally, use the following command, and rpc-url `htt
 docker run --rm -it \
    -p 8000:8000 \
    --name stellar \
-   stellar/quickstart:soroban-dev@sha256:57e8ab498bfa14c65595fbb01cb94b1cdee9637ef2e6634e59d54f6958c05bdb \
+   stellar/quickstart:soroban-dev@sha256:ed57f7a7683e3568ae401f5c6e93341a9f77d8ad41191bf752944d7898981e0c \
    --futurenet \
    --enable-soroban-rpc
 ```

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -157,7 +157,7 @@ use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
 
 The contract will need to import the types and macros that it needs from the `soroban-sdk` crate. Take a look at [Create a Project](#create-new-project) to see how to setup a project.
 
-Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.  
+Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
 
 Contract inputs must not be references.
 
@@ -171,6 +171,7 @@ impl Contract {
     }
 }
 ```
+
 The `#[contract]` attribute designates the Contract struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it. Contract functions are defined within an `impl` block for the struct, which is annotated with `#[contractimpl]`. It is important to note that contract functions should have names with a maximum length of 32 characters. Additionally, if a function is intended to be invoked from outside the contract, it should be marked with the `pub` visibility modifier. It is common for the first argument of a contract function to be of type `Env`, allowing access to a copy of the Soroban environment, which is typically necessary for various operations within the contract.
 
 Putting those pieces together a simple contract will look like this.

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -152,18 +152,18 @@ Once you've created a project, writing a contract involves writing Rust code in 
 All contracts should begin with `#![no_std]` to ensure that the Rust standard library is not included in the build. The Rust standard library is large and not well suited to being deployed into small programs like those deployed to blockchains.
 
 ```rust
-use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
 ```
 
 The contract will need to import the types and macros that it needs from the `soroban-sdk` crate. Take a look at [Create a Project](#create-new-project) to see how to setup a project.
 
-Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
+Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.  
 
 Contract inputs must not be references.
 
 ```rust
+#[contract]
 pub struct Contract;
-
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
@@ -171,21 +171,21 @@ impl Contract {
     }
 }
 ```
-
-Contract functions live inside an `impl` for a struct. The `impl` block is annotated with `#[contractimpl]`. Contract functions must be given names that are no more than 32 characters long. Functions that are intended to be called externally should be marked with `pub` visibility. The first argument can be an `Env` argument to get a copy of the Soroban environment, which is necessary for most things.
+The `#[contract]` attribute designates the Contract struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it. Contract functions are defined within an `impl` block for the struct, which is annotated with `#[contractimpl]`. It is important to note that contract functions should have names with a maximum length of 32 characters. Additionally, if a function is intended to be invoked from outside the contract, it should be marked with the `pub` visibility modifier. It is common for the first argument of a contract function to be of type `Env`, allowing access to a copy of the Soroban environment, which is typically necessary for various operations within the contract.
 
 Putting those pieces together a simple contract will look like this.
 
 ```rust title="src/lib.rs"
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+        vec![&env, symbol_short!("Hello"), to]
     }
 }
 ```
@@ -201,17 +201,17 @@ Given a simple contract like the contract demonstrated in the Write a Contract s
 
 ```rust
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
 
+#[contract]
 pub struct Contract;
 
 #[contractimpl]
 impl Contract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+        vec![&env, symbol_short!("Hello"), to]
     }
 }
-
 #[cfg(test)]
 mod test;
 ```
@@ -220,8 +220,8 @@ mod test;
 <TabItem value="test.rs" label="src/test.rs" default>
 
 ```rust
-use soroban_sdk::{vec, Env, Symbol};
 use crate::{Contract, ContractClient};
+use soroban_sdk::{vec, Env, Symbol, symbol_short};
 
 #[test]
 fn test() {
@@ -229,10 +229,10 @@ fn test() {
     let contract_id = env.register_contract(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&Symbol::short("Dev"));
+    let words = client.hello(&symbol_short!("Dev"));
     assert_eq!(
         words,
-        vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]
+        vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
     );
 }
 ```
@@ -256,7 +256,7 @@ All public functions within an `impl` block that is annotated with the `#[contra
 
 ```rust
 let client = ContractClient::new(&env, &contract_id);
-let words = client.hello(&Symbol::short("Dev"));
+let words = client.hello(&symbol_short!("Dev"));
 ```
 
 The values returned by functions can be asserted on:
@@ -264,7 +264,7 @@ The values returned by functions can be asserted on:
 ```rust
 assert_eq!(
     words,
-    vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]
+    vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
 );
 ```
 

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -135,7 +135,7 @@ To access a given type of storage, use `Env.storage().persistent()`, `Env.storag
 Each storage type is in a separate key space. To demonstrate this, see the code snippet below:
 
 ```rust
-const EXAMPLE_KEY: Symbol = Symbol::short("KEY");
+const EXAMPLE_KEY: Symbol = symbol_short!("KEY");
 env.storage().persistent().set(&EXAMPLE_KEY, 1);
 env.storage().temporary().set(&EXAMPLE_KEY, 2);
 

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -43,8 +43,12 @@ test test::test ... ok
 ## Code
 
 ```rust title="increment/src/lib.rs"
-const COUNTER: Symbol = Symbol::short("COUNTER");
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec, log};
 
+const COUNTER: Symbol = symbol_short!("COUNTER");
+
+#[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
@@ -88,11 +92,10 @@ a later time to lookup the value.
 character space (only `a-zA-z0-9_` characters are allowed). Identifiers like 
 contract function names are represented by `Symbol`s.
 
-Short `Symbol`s up to 9 characters long can be pre-computed at compile time using
-`Symbol::short`.
+The `symbol_short!()` macro is a convenient way to pre-compute short symbols up to 9 characters in length at compile time using `Symbol::short`. It generates a compile-time constant that adheres to the valid character set of letters (a-zA-Z), numbers (0-9), and underscores (_). If a symbol exceeds the 9-character limit, `Symbol::new` should be utilized for creating symbols at runtime.
 
 ```rust
-const COUNTER: Symbol = Symbol::short("COUNTER");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 ```
 
 ### Types of Contract data

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -151,12 +151,13 @@ const Learn = () => (
           {`#![no_std]
 use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
 
+#[contract]
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
     pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+        vec![&env, symbol_short!("Hello"), to]
     }
 }`}
         </pre>


### PR DESCRIPTION
This PR adds a description for usage of  #[contract] and symbol_short 