### PR TITLE
fix: move State Expiration to Concepts

### DIFF
--- a/docs/fundamentals-and-concepts/state-expiration.mdx
+++ b/docs/fundamentals-and-concepts/state-expiration.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 10
-title: 8. State Expiration
+sidebar_position: 18
+title: State Expiration
 description: State Expiration Semantics
 ---
 


### PR DESCRIPTION
This is not part of the core onboarding tutorial. It probably belongs in
Fundamentals and Concepts instead.

For background, these docs are attempting to use [Divio's documentation
system](https://documentation.divio.com/), with the "Getting Started"
section as _The_ Tutorial. The "Fundamentals and Concepts" section is
what Divio describes as "Explanation" docs.