### PR TITLE
updated versions of preview 10 

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -31,7 +31,7 @@ Preview releases are software releases that are also released to the [Futurenet]
 | Soroban RPC                  | `v0.9.1`                                                                                                                           |
 | Stellar Horizon              | `stellar-horizon:2.26.1~soroban-373`                                                                                               |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                             |
-| Stellar Quickstart           | `stellar/quickstart:soroban-devsha256:8a99332f834ca82e3ac1418143736af59b5288e792d1c4278d6c547c6ed8da3b`                           |
+| Stellar Quickstart           | `stellar/quickstart:soroban-dev@sha256:8a99332f834ca82e3ac1418143736af59b5288e792d1c4278d6c547c6ed8da3b`                           |
 | Stellar JS Stellar Base      | `10.0.0-soroban.3`                                                                                                                 |
 | Stellar JS Soroban Client    | `0.9.2`                                                                                                                            |
 | Freighter                    | `5.2.3`                                                                                                                            |

--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -25,15 +25,15 @@ Preview releases are software releases that are also released to the [Futurenet]
 | XDR                          | [e372df9f677961aac04c5a4cc80a3667f310b29f](https://github.com/stellar/stellar-xdr/commit/e372df9f677961aac04c5a4cc80a3667f310b29f) |
 | Soroban Environment          | `v0.0.17`                                                                                                                          |
 | Soroban Interface Version    | `51`                                                                                                                               |
-| Stellar Core                 | `19.12.1-1393.db40326a1.focal~soroban`                                                                                             |
+| Stellar Core                 | `19.12.1-1406.b7d3a8f8d.focal~soroban`                                                                                             |
 | Soroban Rust SDK             | `v0.9.2`                                                                                                                           |
 | Soroban CLI                  | `v0.9.1`                                                                                                                           |
 | Soroban RPC                  | `v0.9.1`                                                                                                                           |
-| Stellar Horizon              | `stellar-horizon:2.26.0~soroban-370`                                                                                               |
+| Stellar Horizon              | `stellar-horizon:2.26.1~soroban-373`                                                                                               |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                             |
-| Stellar Quickstart           | `stellar/quickstart:soroban-dev@sha256:a6b03cf6b0433c99f2f799b719f0faadbb79684b1b763e7674ba749fb0f648ee`                           |
+| Stellar Quickstart           | `stellar/quickstart:soroban-devsha256:8a99332f834ca82e3ac1418143736af59b5288e792d1c4278d6c547c6ed8da3b`                           |
 | Stellar JS Stellar Base      | `10.0.0-soroban.3`                                                                                                                 |
-| Stellar JS Soroban Client    | `0.9.1`                                                                                                                            |
+| Stellar JS Soroban Client    | `0.9.2`                                                                                                                            |
 | Freighter                    | `5.2.3`                                                                                                                            |
 | Laboratory                   | `2.11.0`                                                                                                                           |
 | Soroban React Payment dapp   | `1.1.0`                                                                                                                            |


### PR DESCRIPTION
some newer versions of preview 10 components for core, quickstart, horizon were cut on on july 21st, reflecting those here in release docs.