### PR TITLE
Updating `soroban-cli` version and adding bash completion note

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -116,7 +116,7 @@ To enable autocomplete in the current bash shell, run:
 source <(soroban completion --shell bash)
 ```
 
-To enable autocomplete permanently in all bash shells, run:
+To enable autocomplete permanently in future bash shells, run:
 
 ```bash
 echo "source <(soroban completion --shell bash)" >> ~/.bashrc

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -22,21 +22,21 @@ command.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-If you use Windows, or need an alternative method of installing Rust, check out:  
+If you use Windows, or need an alternative method of installing Rust, check out:
 https://www.rust-lang.org/tools/install
 
 ## Install the target
 
 Install the `wasm32-unknown-unknown` target.
 
-```sh
+```bash
 rustup target add wasm32-unknown-unknown
 ```
 
 ## Configure an Editor
 
 Many editors have support for Rust. Visit the following link to find out how to
-configure your editor:  
+configure your editor:
 https://www.rust-lang.org/tools
 
 A popular editor is Visual Studio Code:
@@ -56,8 +56,8 @@ contract will execute on network, however in a local sandbox.
 
 Install the Soroban CLI using `cargo install`.
 
-```sh
-cargo install --locked --version 0.9.1 soroban-cli
+```bash
+cargo install --locked --version 0.9.4 soroban-cli
 ```
 
 :::info
@@ -71,18 +71,18 @@ Report issues and share feedback about the Soroban CLI
 
 Run the `soroban` command and you should see output like below.
 
-```sh
+```bash
 soroban
 ```
 
-```
-❯ soroban
+```bash
+$ soroban
 Build, deploy, & interact with contracts; set identities to sign with; configure networks; generate keys; and more.
 
 Intro: https://soroban.stellar.org
 CLI Reference: https://github.com/stellar/soroban-tools/tree/main/docs/soroban-cli-full-docs.md
 
-Usage: soroban <COMMAND>
+Usage: soroban [OPTIONS] <COMMAND>
 
 Commands:
   contract    Tools for smart contract developers
@@ -93,9 +93,24 @@ Commands:
   completion  Print shell completion code for the specified shell
 
 Options:
-  -h, --help     Print help (see more with '--help')
-  -V, --version  Print version
+      --global                     Use global config
+  -f, --filter-logs <FILTER_LOGS>  Filter logs output. To turn on "soroban_cli::log::footprint=debug" or off "=off". Can also use env var `RUST_LOG`
+  -q, --quiet                      Do not write logs to stderr including `INFO`
+  -v, --verbose                    Log DEBUG events
+      --very-verbose               Log DEBUG and TRACE events
+      --list                       List installed plugins. E.g. `soroban-hello`
+  -h, --help                       Print help (see more with '--help')
+  -V, --version                    Print version
+
+TESTING_OPTIONS:
+      --config-dir <CONFIG_DIR>
 ```
+
+:::info
+
+**Protip:** You can use `soroban completion` to generate shell completion for `bash`, `elvish`, `fish`, `powershell`, and `zsh`. You should absolutely try it out. It will feel like a super power!!
+
+:::
 
 [Rust]: https://www.rust-lang.org/
 [Soroban CLI]: setup#install-the-soroban-cli

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -110,6 +110,20 @@ TESTING_OPTIONS:
 
 **Protip:** You can use `soroban completion` to generate shell completion for `bash`, `elvish`, `fish`, `powershell`, and `zsh`. You should absolutely try it out. It will feel like a super power!!
 
+To enable autocomplete in the current bash shell, run:
+
+```bash
+source <(soroban completion --shell bash)
+```
+
+To enable autocomplete permanently in all bash shells, run:
+
+```bash
+echo "source <(soroban completion --shell bash)" >> ~/.bashrc
+```
+
+Users of non-bash shells may need to adapt the above commands to suit their needs.
+
 :::
 
 [Rust]: https://www.rust-lang.org/


### PR DESCRIPTION
Issue #526 

Recommending that people should enable bash completion. I made it pretty simple, should I include a more "comprehensive" set of instructions? Seems like there's a lot of variation in what needs to be _done_ with the bash completion stuff, so maybe not that useful?