### PR TITLE
docs: Written content for the liquidity pool advanced tutorial

### DIFF
--- a/docs/TUTORIAL-TEMPLATE.mdx
+++ b/docs/TUTORIAL-TEMPLATE.mdx
@@ -1,0 +1,175 @@
+---
+sidebar_position: 1000
+title: How-To Guides Template
+description: A description of the how-to guide that is being written
+draft: true
+---
+
+Quick note about what this [example demonstrates]. Maybe it's also based on some
+other example.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+
+:::tip
+
+Place each link definition at the bottom of the section it (first) is used In
+
+:::
+
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.9.2
+[example demonstrates]: https://github.com/stellar/soroban-examples/tree/v0.9.2/hello_world
+[other example]: getting-started/
+
+## Run the Example
+
+First go through the [Setup] process to get your development environment
+configured, then clone the `v0.9.2` tag of `soroban-examples` repository:
+
+```bash
+git clone -b v0.9.2 https://github.com/stellar/soroban-examples
+```
+
+Or, skip the development environment setup and open this example in
+[Gitpod][oigp].
+
+To run the tests for the example, navigate to the `hello_world` directory, and
+use `cargo test`.
+
+```bash
+cd hello_world
+cargo test
+```
+
+You should see the output:
+
+```bash
+running 1 test
+test test::test ... ok
+```
+
+[Setup]: ./getting-started/setup.mdx
+
+## Code
+
+```rust title="hello_world/src/lib.rs"
+#![no_std]
+use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+
+pub struct HelloContract;
+
+#[contractimpl]
+impl HelloContract {
+    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+        vec![&env, Symbol::short("Hello"), to]
+    }
+}
+
+mod test;
+```
+
+Ref: https://github.com/stellar/soroban-examples/tree/v0.9.2/hello_world
+
+## How it Works
+
+This is the written part of each guide. You can call out each thing unique to
+this contract, sometimes referencing other important concepts from other example
+contracts, too.
+
+### Major Concepts
+
+You could add sub-headings for highlighting even further important bits or
+concepts to know. The `events` example guide has the following `h3` headings:
+
+- Event Topics
+- Event Data
+- Publishing
+
+Underneath each of those headings is a brief discussion of how that concept ties
+into the example contract code.
+
+## Tests
+
+Open the `/hello_world/src/test.rs` file to follow along.
+
+```rust title="hello_world/src/test.rs"
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{vec, Env, Symbol};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HelloContract);
+    let client = HelloContractClient::new(&env, &contract_id);
+
+    let words = client.hello(&Symbol::short("Dev"));
+    assert_eq!(
+        words,
+        vec![&env, Symbol::short("Hello"), Symbol::short("Dev"),]
+    );
+}
+```
+
+You can describe what's happening in the above test here. Some of the stuff will
+likely be the same from one guide to another. It looks like, in particular, the
+following chunk is shared among a few of them:
+
+{/* BEGIN shared chunk */}
+
+In any test the first thing that is always required is an `Env`, which is the
+Soroban environment that the contract will run in.
+
+```rust
+let env = Env::default();
+```
+
+The contract is registered with the environment using the contract type.
+
+```rust
+let contract_id = env.register_contract(None, IncrementContract);
+```
+
+All public functions within an `impl` block that is annotated with the
+`#[contractimpl]` attribute have a corresponding function generated in a
+generated client type. The client type will be named the same as the contract
+type with `Client` appended. For example, in our contract the contract type is
+`Contract`, and the client is named `ContractClient`.
+
+{/* /END shared chunk */}
+
+Then you can describe the intricacies of what your contract test does uniquely.
+
+## Build the Contract
+
+To build the contract, use the `cargo build` command.
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+A `.wasm` file should be outputted in the `target` directory:
+
+```bash
+target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm
+```
+
+## Run the Contract
+
+If you have [`soroban-cli`] installed, you can invoke contract functions using
+it.
+
+```bash
+soroban contract invoke \
+    --wasm target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm \
+    --id 1 \
+    -- \
+    hello \
+    --to Soroban
+```
+
+## Further Reading
+
+If you have some further links to share or background knowledge you can link to,
+this is the place to share it. Or, maybe you want to point out how this example
+is similar or not when compared with other examples.

--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -18,12 +18,11 @@ description: Fuzz test contracts with cargo-fuzz.
   />
 </head>
 
-The [fuzzing example] demonstrates how to fuzz test Soroban contracts
-with [`cargo-fuzz`] and customize the input to fuzz tests
-with the [`arbitrary`] crate. It also demonstrates
-how to adapt fuzz tests into reusable property tests with the
-[`proptest`] and [`proptest-arbitrary-interop`] crates.
-It builds on the [timelock example].
+The [fuzzing example] demonstrates how to fuzz test Soroban contracts with
+[`cargo-fuzz`] and customize the input to fuzz tests with the [`arbitrary`]
+crate. It also demonstrates how to adapt fuzz tests into reusable property tests
+with the [`proptest`] and [`proptest-arbitrary-interop`] crates. It builds on
+the [timelock example].
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 [oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.9.2
@@ -42,23 +41,22 @@ configured, then clone the `v0.9.2` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
-```
+```bash
 git clone -b v0.9.2 https://github.com/stellar/soroban-examples
 ```
 
-You will also need the `cargo-fuzz` tool,
-and to run `cargo-fuzz` you will need a nightly Rust toolchain:
+You will also need the `cargo-fuzz` tool, and to run `cargo-fuzz` you will need
+a nightly Rust toolchain:
 
-```
+```bash
 cargo install cargo-fuzz
 rustup install nightly
 ```
 
-To run one of the fuzz tests,
-navigate to the `fuzzing` directory
-and run the `cargo fuzz` subcommand with the `nightly` toolchain:
+To run one of the fuzz tests, navigate to the `fuzzing` directory and run the
+`cargo fuzz` subcommand with the `nightly` toolchain:
 
-```
+```bash
 cd fuzzing
 cargo +nightly fuzz run fuzz_target_1
 ```
@@ -84,79 +82,67 @@ INFO: seed corpus: files: 105 min: 32b max: 61b total: 3558b rss: 86Mb
 #8      pulse  cov: 8495 ft: 12420 corp: 4/128b exec/s: 4 rss: 315Mb
 ```
 
-The rest of this tutorial will explain how to set up this fuzz test,
-interpret this output,
-and remedy fuzzing failures.
+The rest of this tutorial will explain how to set up this fuzz test, interpret
+this output, and remedy fuzzing failures.
 
 ## Background: fuzz testing and Rust
 
-Fuzzing is a kind of testing where new inputs are repeatedly fed into
-a program in hopes of finding unexpected bugs.
-This style of testing is commonly employed to increase confidence
-in the correctness of security-sensitive software.
+Fuzzing is a kind of testing where new inputs are repeatedly fed into a program
+in hopes of finding unexpected bugs. This style of testing is commonly employed
+to increase confidence in the correctness of security-sensitive software.
 
-In Rust, fuzzing is most often performed with the [`cargo-fuzz`] tool,
-which drives LLVM's [`libfuzzer`], though other fuzzing tools are available.
+In Rust, fuzzing is most often performed with the [`cargo-fuzz`] tool, which
+drives LLVM's [`libfuzzer`], though other fuzzing tools are available.
 
 [`libfuzzer`]: https://llvm.org/docs/LibFuzzer.html
 
 Soroban has built-in support for fuzzing Soroban contracts with `cargo-fuzz`.
 
-`cargo-fuzz` is a mutation-based fuzzer:
-it runs a test program, passing it generated input;
-while the program is executing,
-the fuzzer monitors which branches the program takes,
-and which functions it executes;
-after execution the fuzzer uses this information
-to make decisions about how to _mutate_ the previously-used input
-to create new input that might discover more branches and functions;
-it then runs the test again with new input,
-repeating this process for potentially millions of iterations.
-In this way `cargo-fuzz` is able to automatically explore
-execution paths through the program that may never be seen
+`cargo-fuzz` is a mutation-based fuzzer: it runs a test program, passing it
+generated input; while the program is executing, the fuzzer monitors which
+branches the program takes, and which functions it executes; after execution the
+fuzzer uses this information to make decisions about how to _mutate_ the
+previously-used input to create new input that might discover more branches and
+functions; it then runs the test again with new input, repeating this process
+for potentially millions of iterations. In this way `cargo-fuzz` is able to
+automatically explore execution paths through the program that may never be seen
 by other types of tests.
 
-If a fuzz tests panics or hard-crashes,
-`cargo-fuzz` considers it a failure
-and provides instructions for repeating the test with the failing inputs.
+If a fuzz tests panics or hard-crashes, `cargo-fuzz` considers it a failure and
+provides instructions for repeating the test with the failing inputs.
 
-Fuzz testing is typically an exploratory and interactive process,
-with the programmer devising schemes for producing input that
-will stress the program in interesting ways,
-observing the behavior of the fuzz test,
-and iterating on the test itself.
+Fuzz testing is typically an exploratory and interactive process, with the
+programmer devising schemes for producing input that will stress the program in
+interesting ways, observing the behavior of the fuzz test, and iterating on the
+test itself.
 
-Resolving a fuzz testing failure typically involves
-capturing the problematic input in a unit test.
-The fuzz test itself may or may not be kept,
-depending on determinations about the cost of maintaining the fuzzer
-vs the likelihood of it continuing to find bugs in the future.
+Resolving a fuzz testing failure typically involves capturing the problematic
+input in a unit test. The fuzz test itself may or may not be kept, depending on
+determinations about the cost of maintaining the fuzzer vs the likelihood of it
+continuing to find bugs in the future.
 
-While fuzzing non-memory-safe software tends to be more lucrative
-than fuzzing Rust software,
-it is still relatively common to find panics and other logic errors
-in Rust through fuzzing.
+While fuzzing non-memory-safe software tends to be more lucrative than fuzzing
+Rust software, it is still relatively common to find panics and other logic
+errors in Rust through fuzzing.
 
-In Rust, multiple fuzzers are maintained by the
-[`rust-fuzz`] GitHub organization,
-which also maintains a "trophy case" of Rust bugs found through fuzzing.
+In Rust, multiple fuzzers are maintained by the [`rust-fuzz`] GitHub
+organization, which also maintains a "trophy case" of Rust bugs found through
+fuzzing.
 
 [`rust-fuzz`]: https://github.com/rust-fuzz
 
 ## About the example
 
-The example used for this tutorial is based on the [`timelock`]
-example program, with some changes to demonstrate fuzzing.
+The example used for this tutorial is based on the [`timelock`] example program,
+with some changes to demonstrate fuzzing.
 
 [`timelock`]: https://github.com/stellar/soroban-examples/tree/v0.9.2/timelock
 
-The contract, `ClaimableBalanceContract`,
-allows one party to deposit
-an arbitrary quantity of a token to the contract,
-specifying additionally:
-the `claimants`, addresses that may withdraw from the contract;
-and the `time_bound`, a specification of when
-those claimants may withdraw from the account.
+The contract, `ClaimableBalanceContract`, allows one party to deposit an
+arbitrary quantity of a token to the contract, specifying additionally: the
+`claimants`, addresses that may withdraw from the contract; and the
+`time_bound`, a specification of when those claimants may withdraw from the
+account.
 
 The `TimeBound` type looks like
 
@@ -176,8 +162,7 @@ pub enum TimeBoundKind {
 }
 ```
 
-`ClaimableBalanceContract` has two methods,
-`deposit` and `claim`:
+`ClaimableBalanceContract` has two methods, `deposit` and `claim`:
 
 ```rust
     pub fn deposit(
@@ -196,31 +181,27 @@ pub enum TimeBoundKind {
     );
 ```
 
-`deposit` may only be successfully called once,
-after which `claim` may be called multiple times
-until the balance is completely drained,
-at which point the contract becomes dormant
-and may no longer be used.
+`deposit` may only be successfully called once, after which `claim` may be
+called multiple times until the balance is completely drained, at which point
+the contract becomes dormant and may no longer be used.
 
 ## Fuzz testing setup
 
-For these examples, the fuzz tests have been created for you,
-but normally you would use the `cargo fuzz init` command
-to create a fuzzing project as a subdirectory of the contract
-under test.
+For these examples, the fuzz tests have been created for you, but normally you
+would use the `cargo fuzz init` command to create a fuzzing project as a
+subdirectory of the contract under test.
 
-To do that you would navigate to the contract directory,
-in this case, `soroban-examples/fuzzing`, and execute
+To do that you would navigate to the contract directory, in this case,
+`soroban-examples/fuzzing`, and execute
 
-```
+```bash
 cargo fuzz init
 ```
 
-A `cargo-fuzz` project is its own crate,
-which lives in the `fuzz` subdirectory of the crate being
-tested. This crate has its own `Cargo.toml` and `Cargo.lock`,
-and another subdirectory, `fuzz_targets`, which contains
-Rust programs, each its own fuzz test.
+A `cargo-fuzz` project is its own crate, which lives in the `fuzz` subdirectory
+of the crate being tested. This crate has its own `Cargo.toml` and `Cargo.lock`,
+and another subdirectory, `fuzz_targets`, which contains Rust programs, each its
+own fuzz test.
 
 Our `soroban-examples/fuzzing` directory looks like
 
@@ -235,15 +216,14 @@ Our `soroban-examples/fuzzing` directory looks like
     - `fuzz_target_1.rs` - this is a single fuzz test
     - `fuzz_target_2.rs`
 
-There are special considerations to note
-in the configuration of both the [contract's manifest]
-and the [fuzzing crate's manifest].
+There are special considerations to note in the configuration of both the
+[contract's manifest] and the [fuzzing crate's manifest].
 
 [contract's manifest]: https://github.com/stellar/soroban-examples/tree/v0.9.2/fuzzing/Cargo.toml
 [fuzzing crate's manifest]: https://github.com/stellar/soroban-examples/tree/v0.9.2/fuzzing/fuzz/Cargo.toml
 
-Within the contract's manifest one must
-specificy the crate type as both "cdylib" and "rlib":
+Within the contract's manifest one must specificy the crate type as both
+"cdylib" and "rlib":
 
 ```toml
 [package]
@@ -262,27 +242,30 @@ doctest = false
 testutils = []
 ```
 
-In most examples, a Soroban contract will only be a "cdylib",
-a Rust crate that is compiled to a dynamically loadable wasm module.
-For fuzzing though, the fuzzing crate needs to be able to link
-to the contract crate as a Rust library, an "rlib".
+In most examples, a Soroban contract will only be a "cdylib", a Rust crate that
+is compiled to a dynamically loadable wasm module. For fuzzing though, the
+fuzzing crate needs to be able to link to the contract crate as a Rust library,
+an "rlib".
 
-> Note that cargo has a [feature/bug that inhibits LTO][lto] of cdylibs when
-> a crate is both a "cdylib" and "rlib".
-> This can be worked around by building the contract with either
-> `soroban contract build` or `cargo rustc --crate-type cdylib`
-> instead of the typical `cargo build`.
+:::note
+
+Note that cargo has a [feature/bug that inhibits LTO][lto] of cdylibs when a
+crate is both a "cdylib" and "rlib". This can be worked around by building the
+contract with either `soroban contract build` or `cargo rustc --crate-type
+cdylib` instead of the typical `cargo build`.
+
+:::
 
 [lto]: https://github.com/stellar/soroban-docs/pull/476
 
-The contract crate must also provide the "testutils" feature.
-When "testutils" is activated, the Soroban SDK's [`contracttype`] macro emits
-additional code needed for running fuzz tests.
+The contract crate must also provide the "testutils" feature. When "testutils"
+is activated, the Soroban SDK's [`contracttype`] macro emits additional code
+needed for running fuzz tests.
 
 [`contracttype`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/attr.contracttype.html
 
-Within the fuzzing crate's manifest one must turn on the
-"testutils" features in both the contract crate and the `soroban-sdk` crate:
+Within the fuzzing crate's manifest one must turn on the "testutils" features in
+both the contract crate and the `soroban-sdk` crate:
 
 ```toml
 [package]
@@ -305,22 +288,20 @@ features = ["testutils"]
 
 ## A simple fuzz test
 
-First let's look at [`fuzz_target_1.rs`].
-This fuzz test does two things:
-it first deposits an arbitrary amount,
-then it claims an arbitrary amount.
+First let's look at [`fuzz_target_1.rs`]. This fuzz test does two things: it
+first deposits an arbitrary amount, then it claims an arbitrary amount.
 
 [`fuzz_target_1.rs`]: https://github.com/stellar/soroban-examples/tree/v0.9.2/fuzzing/fuzz/fuzz_targets/fuzz_target_1.rs
 
-Again, you can run this fuzzer from the `soroban-examples/fuzzing`
-directory with the following command:
+Again, you can run this fuzzer from the `soroban-examples/fuzzing` directory
+with the following command:
 
-```
+```bash
 cargo +nightly fuzz run fuzz_target_1
 ```
 
-The entry point and setup code for Soroban
-contract fuzz tests will typically look like:
+The entry point and setup code for Soroban contract fuzz tests will typically
+look like:
 
 ```rust
 #[derive(Arbitrary, Debug)]
@@ -349,31 +330,27 @@ fuzz_target!(|input: Input| {
 }
 ```
 
-Instead of a `main` function,
-`cargo-fuzz` uses a special entry point defined
-by the [`fuzz_target!`] macro. This macro accepts
-a Rust closure that accepts `input`,
-any Rust type that implements the [`Arbitrary`] trait.
-Here we have defined a struct, `Input`, that derives `Arbitrary`.
+Instead of a `main` function, `cargo-fuzz` uses a special entry point defined by
+the [`fuzz_target!`] macro. This macro accepts a Rust closure that accepts
+`input`, any Rust type that implements the [`Arbitrary`] trait. Here we have
+defined a struct, `Input`, that derives `Arbitrary`.
 
 [`fuzz_target!`]: https://docs.rs/libfuzzer-sys/latest/libfuzzer_sys/macro.fuzz_target.html
 [`Arbitrary`]: https://docs.rs/arbitrary/latest/arbitrary/trait.Arbitrary.html
 
-`cargo-fuzz` will be responsible for generating `input`
-and repeatedly calling this closure.
+`cargo-fuzz` will be responsible for generating `input` and repeatedly calling
+this closure.
 
-To test a Soroban contract, we must set up an [`Env`].
-Note that we have disabled the CPU and memory budget:
-this will allow us to fuzz arbitrarily complex code paths
-without worrying about running out of budget;
-we can assume that running out of budget during a transaction
-always correctly fails, canceling the transaction;
-it is not something we need to fuzz.
+To test a Soroban contract, we must set up an [`Env`]. Note that we have
+disabled the CPU and memory budget: this will allow us to fuzz arbitrarily
+complex code paths without worrying about running out of budget; we can assume
+that running out of budget during a transaction always correctly fails,
+canceling the transaction; it is not something we need to fuzz.
 
 [`Env`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html
 
-Refer to the [`fuzz_target_1.rs`] source code for
-additional setup for this contract.
+Refer to the [`fuzz_target_1.rs`] source code for additional setup for this
+contract.
 
 This fuzzer performs two steps: deposit, then claim:
 
@@ -422,38 +399,29 @@ This fuzzer performs two steps: deposit, then claim:
     }
 ```
 
-There are a number of potential strategies for writing fuzz tests.
-The strategy in this test is to make arbitrary,
-possibly weird and unrealistic,
-calls to the contract,
-disregarding whether those calls succeed or fail,
-and then to make assertions about the state of the contract.
+There are a number of potential strategies for writing fuzz tests. The strategy
+in this test is to make arbitrary, possibly weird and unrealistic, calls to the
+contract, disregarding whether those calls succeed or fail, and then to make
+assertions about the state of the contract.
 
-Because there are many potential failure cases for
-any given contract call,
-we don't want to write a fuzz test by attempting to interpret
-the success or failure of any given call:
-that path leads to duplicating the contract's logic
-within the fuzz test.
-Instead we just want to ensure that,
-regardless of what happened during execution,
-the contract is never left in an invalid state.
+Because there are many potential failure cases for any given contract call, we
+don't want to write a fuzz test by attempting to interpret the success or
+failure of any given call: that path leads to duplicating the contract's logic
+within the fuzz test. Instead we just want to ensure that, regardless of what
+happened during execution, the contract is never left in an invalid state.
 
-Notice the use of the [`fuzz_catch_panic`] function
-to invoke the contract:
-This is a special function in the Soroban SDK for
-intercepting panics in a way that works with `cargo-fuzz`,
-and is needed to call contract functions that might fail.
-Without `fuzz_catch_panic` a panic from within a contract
-will immediately cause the fuzz test to fail,
-but in most cases a panic within a contract does not indicate
-a bug - it is simply how a Soroban contract cancels a transaction.
+Notice the use of the [`fuzz_catch_panic`] function to invoke the contract: This
+is a special function in the Soroban SDK for intercepting panics in a way that
+works with `cargo-fuzz`, and is needed to call contract functions that might
+fail. Without `fuzz_catch_panic` a panic from within a contract will immediately
+cause the fuzz test to fail, but in most cases a panic within a contract does
+not indicate a bug - it is simply how a Soroban contract cancels a transaction.
 `fuzz_catch_panic` returns a `Result`, but here we discard it.
 
 [`fuzz_catch_panic`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/arbitrary/fn.fuzz_catch_panic.html
 
-Finally, the `assert_invariants` function is where
-we make any assertions we can about the state of the contract:
+Finally, the `assert_invariants` function is where we make any assertions we can
+about the state of the contract:
 
 ```rust
 /// Directly inspect the contract state and make assertions about it.
@@ -503,9 +471,8 @@ fn assert_invariants(
 
 ## Interpreting `cargo-fuzz` output
 
-If you run `cargo-fuzz` with `fuzz_target_1`,
-from inside the `soroban-examples/fuzzing` directory,
-you will see output similar to:
+If you run `cargo-fuzz` with `fuzz_target_1`, from inside the
+`soroban-examples/fuzzing` directory, you will see output similar to:
 
 ```
 $ cargo +nightly fuzz run fuzz_target_1
@@ -602,23 +569,23 @@ Minimize test case with:
         cargo fuzz tmin fuzz_target_1 fuzz/artifacts/fuzz_target_1/crash-04704b1542f61a21a4649e39023ec57ff502f627
 ```
 
-The first line here is printed by our Rust program,
-and indicates exactly where the fuzzer panicked.
-The later lines indicate how to reproduce this failing case.
+The first line here is printed by our Rust program, and indicates exactly where
+the fuzzer panicked. The later lines indicate how to reproduce this failing
+case.
 
-The first thing to do when you get a fuzzing failure is copy
-the command to reproduce the failure,
-so that you can use it to debug:
+The first thing to do when you get a fuzzing failure is copy the command to
+reproduce the failure, so that you can use it to debug:
 
-```
+```bash
 cargo +nightly fuzz run fuzz_target_1 fuzz/artifacts/fuzz_target_1/crash-04704b1542f61a21a4649e39023ec57ff502f627
 ```
 
-Notice though that we need to tell `cargo` to use the nightly toolchain with the `+nightly` flag,
-something that `cargo-fuzz` doesn't print in its version of the command.
+Notice though that we need to tell `cargo` to use the nightly toolchain with the
+`+nightly` flag, something that `cargo-fuzz` doesn't print in its version of the
+command.
 
-Another thing to notice is that by default, `cargo-fuzz` / `libfuzzer` does not print
-names of functions in its output, as in the stack trace:
+Another thing to notice is that by default, `cargo-fuzz` / `libfuzzer` does not
+print names of functions in its output, as in the stack trace:
 
 ```
 ==6102== ERROR: libFuzzer: deadly signal
@@ -633,11 +600,12 @@ Depending on how your system is set up, you may or may not have this problem.
 In order to print stack traces, `libfuzzer` needs the `llvm-symbolizer` program.
 On Ubuntu-based systems this can be installed with the `llvm-dev` package:
 
-```
+```bash
 $ sudo apt install llvm-dev
 ```
 
-After which `libfuzzer` will print demangled function names instead of addresses:
+After which `libfuzzer` will print demangled function names instead of
+addresses:
 
 ```
 ==6323== ERROR: libFuzzer: deadly signal
@@ -659,13 +627,11 @@ After which `libfuzzer` will print demangled function names instead of addresses
     #39 0x557c9d9c837d in _start (/home/azureuser/data/stellar/soroban-examples/fuzzing/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1+0x1bde37d) (BuildId: 6a95a932984a405ebab8171dddc9f812fdf16846)
 ```
 
-To continue,
-our program has a bug that should be easy to fix by inspecting the error
-and making a slight modification to the source.
+To continue, our program has a bug that should be easy to fix by inspecting the
+error and making a slight modification to the source.
 
-Once the bug is fixed,
-the fuzzer will run continuously,
-producing output that looks like
+Once the bug is fixed, the fuzzer will run continuously, producing output that
+looks like
 
 ```
 $ cargo +nightly fuzz run fuzz_target_1
@@ -709,35 +675,34 @@ And this output will continue until the fuzzer is killed with `Ctrl-C`.
 
 Next, let's look at a single line of fuzzer output:
 
-```
+```bash
 #177    NEW    cov: 8545 ft: 13821 corp: 43/1419b lim: 48 exec/s: 29 rss: 384Mb L: 32/48 MS: 1 ChangeASCIIInt-
 ```
 
-The most important column here is `cov`. This is a cumulative measure of branches
-covered by the fuzzer. When this number stops increasing the fuzzer has probably
-explored as much of the program as it can.
-The other columns are described in the [`libfuzzer` documentation][lfout].
+The most important column here is `cov`. This is a cumulative measure of
+branches covered by the fuzzer. When this number stops increasing the fuzzer has
+probably explored as much of the program as it can. The other columns are
+described in the [`libfuzzer` documentation][lfout].
 
 [lfout]: https://llvm.org/docs/LibFuzzer.html#output
 
 Finally, lets look at this warning:
 
-```
+```bash
 INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes.
 ```
 
-By default, `libfuzzer` only generates input up to 4096 bytes.
-In a lot of cases, this is probably reasonable,
-but `cargo-fuzz` can increase the `max_len` by appending the argument
-after `--`:
+By default, `libfuzzer` only generates input up to 4096 bytes. In a lot of
+cases, this is probably reasonable, but `cargo-fuzz` can increase the `max_len`
+by appending the argument after `--`:
 
-```
+```bash
 $ cargo +nightly fuzz run fuzz_target_1 -- -max_len=20000
 ```
 
 All the options to libfuzzer can be listed with
 
-```
+```bash
 $ cargo +nightly fuzz run fuzz_target_1 -- -help=1
 ```
 
@@ -747,25 +712,27 @@ See the [`libfuzzer` documentation] for more.
 
 ## Accepting Soroban types as input with the `SorobanArbitrary` trait
 
-Inputs to the `fuzz_target!` macro must implement the [`Arbitrary`] trait,
-which accepts bytes from the fuzzer driver and converts them to Rust values.
-Soroban types though are managed by the host environment, and so must be created
-from an [`Env`] value, which is not available to the fuzzer driver.
-The [`SorobanArbitrary`] trait, implemented for all
-Soroban contract types, exists to bridge this gap: it defines a _prototype_
-pattern whereby the `fuzz_target` macro creates prototype values that the
-fuzz program can convert to contract values with the standard soroban
-conversion traits, [`FromVal`] or [`IntoVal`].
+Inputs to the `fuzz_target!` macro must implement the [`Arbitrary`] trait, which
+accepts bytes from the fuzzer driver and converts them to Rust values. Soroban
+types though are managed by the host environment, and so must be created from an
+[`Env`] value, which is not available to the fuzzer driver. The
+[`SorobanArbitrary`] trait, implemented for all Soroban contract types, exists
+to bridge this gap: it defines a _prototype_ pattern whereby the `fuzz_target`
+macro creates prototype values that the fuzz program can convert to contract
+values with the standard soroban conversion traits, [`FromVal`] or [`IntoVal`].
+This is yet another way Soroban provides a "[batteries-included]" developer
+experience!
 
 [`SorobanArbitrary`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/arbitrary/trait.SorobanArbitrary.html
 [`Env`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html
 [`FromVal`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/trait.FromVal.html
 [`IntoVal`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/trait.IntoVal.html
+[batteries-included]: https://foddy.net/Athletics.html?webgl=true
 
 The types of prototypes are identified by the associated type,
 `SorobanArbitrary::Prototype`:
 
-```
+```rust
 pub trait SorobanArbitrary:
     TryFromVal<Env, Self::Prototype> + IntoVal<Env, Val> + TryFromVal<Env, Val>
 {
@@ -793,12 +760,12 @@ Types that implement `SorobanArbitrary` include:
 [`Val`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Val.html
 
 All user-defined contract types, those with the [`contracttype`] attribute,
-automatically derive `SorobanArbitrary`. Note that `SorobanArbitrary` is
-only derived when the "testutils" Cargo feature is active. This implies
-that, in general, to make a Soroban contract fuzzable, the contract crate
-must define a "testutils" Cargo feature, that feature should turn on the
-"soroban-sdk/testutils" feature, and the fuzz test, which is its own crate,
-must turn that feature on.
+automatically derive `SorobanArbitrary`. Note that `SorobanArbitrary` is only
+derived when the "testutils" Cargo feature is active. This implies that, in
+general, to make a Soroban contract fuzzable, the contract crate must define a
+"testutils" Cargo feature, that feature should turn on the
+"soroban-sdk/testutils" feature, and the fuzz test, which is its own crate, must
+turn that feature on.
 
 [`contracttype`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/macro.contracttype.html
 
@@ -809,17 +776,15 @@ the advancement of time, and more advanced fuzzing techniques.
 
 [`fuzz_target_2.rs`]: https://github.com/stellar/soroban-examples/tree/v0.9.2/fuzzing/fuzz/fuzz_targets/fuzz_target_2.rs
 
-This fuzz test takes a much more complex input,
-where some of the values are user-defined types exported
-from the contract under test.
-This test is structured as a simple interpreter,
-where the fuzzing harness provides arbitrarily-generated "steps",
-where each step is either a `deposit` command or a `claim` command.
-The test then treats each of these steps as a separate transaction:
-it maintains a snapshot of the blockchain state,
-and for each step creates a fresh environment in which to execute
-the contract call, simulating the advancement of time between each step.
-As in the previous example, assertions are made after each step.
+This fuzz test takes a much more complex input, where some of the values are
+user-defined types exported from the contract under test. This test is
+structured as a simple interpreter, where the fuzzing harness provides
+arbitrarily-generated "steps", where each step is either a `deposit` command or
+a `claim` command. The test then treats each of these steps as a separate
+transaction: it maintains a snapshot of the blockchain state, and for each step
+creates a fresh environment in which to execute the contract call, simulating
+the advancement of time between each step. As in the previous example,
+assertions are made after each step.
 
 The input to the fuzzer looks, in part, like:
 
@@ -840,15 +805,13 @@ struct Step {
 }
 ```
 
-This shows how to use the `SorobanArbitrary::Prototype` associated type
-to define inputs to the fuzzer.
-A Soroban [`Address`] can only be created with an [`Env`],
-so cannot be generated directly by the `Arbitrary` trait.
-Instead we use the fully-qualified name of the `Address` prototype,
-`<Address as SorobanArbitrary>::Prototype`,
-to ask for `Address`'s prototype instead.
-Then when our fuzzer needs the `Address` we
-instantiate it with the [`FromVal`] trait:
+This shows how to use the `SorobanArbitrary::Prototype` associated type to
+define inputs to the fuzzer. A Soroban [`Address`] can only be created with an
+[`Env`], so cannot be generated directly by the `Arbitrary` trait. Instead we
+use the fully-qualified name of the `Address` prototype, `<Address as
+SorobanArbitrary>::Prototype`, to ask for `Address`'s prototype instead. Then
+when our fuzzer needs the `Address` we instantiate it with the [`FromVal`]
+trait:
 
 ```rust
 let depositor_address = Address::from_val(&env, &input.addresses[cmd.depositor_index]);
@@ -858,9 +821,9 @@ let depositor_address = Address::from_val(&env, &input.addresses[cmd.depositor_i
 
 ---
 
-The contract we are fuzzing is a _timelock_ contract,
-where calculation of time is crucial for correctness.
-So our testing must account for the advancement of time.
+The contract we are fuzzing is a _timelock_ contract, where calculation of time
+is crucial for correctness. So our testing must account for the advancement of
+time.
 
 The contract defines a `TimeBound` type and accepts it in the `deposit` method:
 
@@ -887,8 +850,8 @@ impl ClaimableBalanceContract {
 }
 ```
 
-In our fuzzer, one of the possible commands issued each step
-is a `DepositCommand`:
+In our fuzzer, one of the possible commands issued each step is a
+`DepositCommand`:
 
 ```rust
 #[derive(Arbitrary, Debug)]
@@ -909,23 +872,21 @@ struct DepositCommand {
 }
 ```
 
-Notice that this command again uses the `SorobanArbitrary::Prototype`
-associated type to accept a `TimeBound` as input.
+Notice that this command again uses the `SorobanArbitrary::Prototype` associated
+type to accept a `TimeBound` as input.
 
-To advance time we maintain a [`LedgerSnapshot`],
-defined in the [`soroban-ledger-snapshot`] crate.
-For each step we call [`Env::from_snapshot`]
-to create a fresh environment to execute the step,
-then [`Env::to_snapshot`] to create a new snapshot
-to use in the following step.
+To advance time we maintain a [`LedgerSnapshot`], defined in the
+[`soroban-ledger-snapshot`] crate. For each step we call [`Env::from_snapshot`]
+to create a fresh environment to execute the step, then [`Env::to_snapshot`] to
+create a new snapshot to use in the following step.
 
 [`LedgerSnapshot`]: https://docs.rs/soroban-ledger-snapshot/latest/soroban_ledger_snapshot/struct.LedgerSnapshot.html
 [`soroban-ledger-snapshot`]: https://docs.rs/soroban-ledger-snapshot
 [`Env::from_snapshot`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html#method.from_snapshot
 [`Env::to_snapshot`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Env.html#method.to_snapshot
 
-Here is a simplified outline of how this works.
-See the full source code for details.
+Here is a simplified outline of how this works. See the full source code for
+details.
 
 ```rust
 let init_snapshot = {
@@ -962,25 +923,23 @@ for step in &config.input.steps {
 
 ## Converting a fuzz test to a property test
 
-In addition to fuzz testing,
-Soroban supports property testing in the style of quickcheck,
-by using the [`proptest`] and [`proptest-arbitrary-interop`] crates
+In addition to fuzz testing, Soroban supports property testing in the style of
+quickcheck, by using the [`proptest`] and [`proptest-arbitrary-interop`] crates
 in conjunction with the `SorobanArbitrary` trait.
 
 [`proptest`]: https://docs.rs/proptest
 [`proptest-arbitrary-interop`]: https://docs.rs/proptest-arbitrary-interop
 
-Property tests are similar to fuzz tests in that they generate
-randomized input. Property tests though do not instrument their
-test cases or mutate their input based on feedback from previous tests.
-Thus they are a weaker form of test.
+Property tests are similar to fuzz tests in that they generate randomized input.
+Property tests though do not instrument their test cases or mutate their input
+based on feedback from previous tests. Thus they are a weaker form of test.
 
 The great benefit of property tests though is that they can be included in
 standard Rust test suites and require no extra tooling to execute. One might
 take advantage of this by interactively fuzzing to discover deep bugs, then
 convert fuzz tests to property tests to help prevent regressions.
 
-The [`proptest.rs`] file is a translation of `fuzz_target_1.rs`
-to a property test.
+The [`proptest.rs`] file is a translation of `fuzz_target_1.rs` to a property
+test.
 
 [`proptest.rs`]: https://github.com/stellar/soroban-examples/tree/v0.9.2/fuzzing/src/proptest.rs

--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -34,7 +34,7 @@ the [timelock example].
 [`proptest-arbitrary-interop`]: https://docs.rs/proptest-arbitrary-interop
 [timelock example]: https://github.com/stellar/soroban-examples/tree/v0.9.2/timelock
 
-## Run the example
+## Run the Example
 
 First go through the [setup] process to get your development environment
 configured, then clone the `v0.9.2` tag of `soroban-examples` repository:
@@ -85,7 +85,7 @@ INFO: seed corpus: files: 105 min: 32b max: 61b total: 3558b rss: 86Mb
 The rest of this tutorial will explain how to set up this fuzz test, interpret
 this output, and remedy fuzzing failures.
 
-## Background: fuzz testing and Rust
+## Background: Fuzz Testing and Rust
 
 Fuzzing is a kind of testing where new inputs are repeatedly fed into a program
 in hopes of finding unexpected bugs. This style of testing is commonly employed
@@ -131,7 +131,7 @@ fuzzing.
 
 [`rust-fuzz`]: https://github.com/rust-fuzz
 
-## About the example
+## About the Example
 
 The example used for this tutorial is based on the [`timelock`] example program,
 with some changes to demonstrate fuzzing.
@@ -185,7 +185,7 @@ pub enum TimeBoundKind {
 called multiple times until the balance is completely drained, at which point
 the contract becomes dormant and may no longer be used.
 
-## Fuzz testing setup
+## Fuzz Testing Setup
 
 For these examples, the fuzz tests have been created for you, but normally you
 would use the `cargo fuzz init` command to create a fuzzing project as a
@@ -286,7 +286,7 @@ path = ".."
 features = ["testutils"]
 ```
 
-## A simple fuzz test
+## A Simple Fuzz Test
 
 First let's look at [`fuzz_target_1.rs`]. This fuzz test does two things: it
 first deposits an arbitrary amount, then it claims an arbitrary amount.
@@ -469,7 +469,7 @@ fn assert_invariants(
 }
 ```
 
-## Interpreting `cargo-fuzz` output
+## Interpreting `cargo-fuzz` Output
 
 If you run `cargo-fuzz` with `fuzz_target_1`, from inside the
 `soroban-examples/fuzzing` directory, you will see output similar to:
@@ -710,7 +710,7 @@ See the [`libfuzzer` documentation] for more.
 
 [`libfuzzer` documentation]: https://llvm.org/docs/LibFuzzer.html#output
 
-## Accepting Soroban types as input with the `SorobanArbitrary` trait
+## Accepting Soroban Types as Input with the `SorobanArbitrary` Trait
 
 Inputs to the `fuzz_target!` macro must implement the [`Arbitrary`] trait, which
 accepts bytes from the fuzzer driver and converts them to Rust values. Soroban
@@ -769,7 +769,7 @@ turn that feature on.
 
 [`contracttype`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/macro.contracttype.html
 
-## A more complex fuzz test
+## A More Complex Fuzz Test
 
 The [`fuzz_target_2.rs`] example, demonstrates the use of `SorobanArbitrary`,
 the advancement of time, and more advanced fuzzing techniques.
@@ -921,7 +921,7 @@ for step in &config.input.steps {
 }
 ```
 
-## Converting a fuzz test to a property test
+## Converting a Fuzz Test to a Property Test
 
 In addition to fuzz testing, Soroban supports property testing in the style of
 quickcheck, by using the [`proptest`] and [`proptest-arbitrary-interop`] crates

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -472,21 +472,90 @@ Ref: https://github.com/stellar/soroban-examples/tree/v0.9.2/liquidity_pool
 
 ## How it Works
 
-Something about how it works
+Every asset created on Stellar starts with zero liquidity. The same is true of
+tokens created on Soroban (unless a Stellar asset with existing liquidity token
+is "wrapped" for use in Soroban). In simple terms, "liquidity" means how much of
+an asset in a market is available to be bough or sold. In the "old days," you
+could generate liquidity in a market by creating buy/sell orders on an order
+book.
+
+Liquidity pools automate this process by substituting the orders with math.
+Depositors into the liquidity pool earn fees from `swap` transactions. No orders
+required!
+
+Open the `liquidity_pool/src/lib.rs` file or see the code above to follow along.
+
+### Initialize the Contract
+
+When this contract is first deployed, it could create a liquidity pool for _any_
+pair of tokens available on Soroban. It must first be initialized with the
+following information:
+
+- **`token_wasm_hash`:** The contract will end up [creating its own `POOL`
+  token] as well as [interacting with contracts for `token_a` and `token_b`].
+  The way this example works is by using the [`token` example contract] for both
+  of these jobs. When our liquidity pool contract is initialized it wants us to
+  pass the wasm hash of the **already deployed** token contract. It will then
+  re-deploy the WASM bytecode that is stored at that hash into a new token
+  contract for the `POOL` tokens.
+- **`token_a`:** The contract `Address` for an **already deployed** (or wrapped)
+  token that will be held in reserve by the liquidity pool.
+- **`token_b`:** The contract `Address` for an **already deployed** (or wrapped)
+  token that will be held in reserve by the liquidity pool.
+
+Bear in mind that which token is `token_a` and which is `token_b` isn't arbitrary.
+In line with the Built-in Stellar liquidity pools, this contract can only make a single liquidity pool for a given set of tokens. So, the token addresses must be provided in [lexicographical order] at initialization.
+
+```rust
+fn initialize(e: Env, token_wasm_hash: BytesN<32>, taken_a: Address, token_b: Address) {
+    if token_a >= token_b {
+        panic!("token_a must be less than token_b");
+    }
+
+    // The initialization function also stores important information in the contract's instance storage
+    put_token_a(&e, token_a);
+    put_token_b(&e, token_b);
+    put_token_share(&e, share_contract.try_into().unwrap());
+    put_total_shares(&e, 0);
+    put_reserve_a(&e, 0);
+    put_reserve_b(&e, 0);
+}
+```
+
+[creating its own `POOL` token]: #creating-a-custom-token-for-lp-shares
+[interacting with contracts for `token_a` and `token_b`]: #token-transfers-tofrom-the-lp-contract
+[`token` example contract]: ./tokens
+[lexicographical order]: https://developers.stellar.org/docs/encyclopedia/liquidity-on-stellar-sdex-liquidity-pools#liquidity-pool-participation
+
+### Make a First Deposit
 
 ### A "Constant Product" Liquidity Pool
 
-We should describe how this is a "constant product" LP, and (briefly) what other
-kinds of LPs exist. We could even go into the **fascinating** math behind how
-the "constant product" and fees are figured.
+The _type_ of liquidity pool this example contract implements is called a "constant product" liquidity pool. While this isn't the only type of liquidity pool out there, it is the most common variety. These liquidity pools are designed to keep the _total_ value of each asset in _relative_ equilibrium. The "product" in the constant product (also called an "invariant") will change every time the liquidity pool is interacted with (deposit, withdraw, or token swaps). However, the invariant **must** only increase with every interaction.
 
-### Contract Metadata
+During a swap, what must be kept in mind is that for every withdrawal from the `token_a` side, you must "refill" the `token_b` side with a sufficient amount to keep the liquidity pool's price balanced. The math is predictable, but it is not linear. The more you take from one side, the more you must give on the opposite site _exponentially_.
 
-This is (I believe) the only example contract that is making use of the
-`contractmeta!()` macro. We should talk about what that does, and how it can be
-useful.
+Inside the `swap` function, the math is done like this (this is a simplified version, however):
 
-### Creating a Custom Token for LP Shares
+```rust
+fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128) {
+    // Get the current balances of both tokens in the liquidity pool
+    let (reserve_sell, reserve_buy) = (get_reserve_a(&e), get_reserve_b(&e));
+
+    // Calculate how much needs to be
+    let n = reserve_sell * out * 1000;
+    let d = (reserve_buy - out) * 997;
+    let sell_amount = (n / d) + 1;
+}
+```
+
+We have much more in-depth information about how this kind of liquidity pool works is available in [Stellar Quest: Series 3, Quest 5]. This is a really useful, interactive way to learn more about how the built-in Stellar liquidity pools work. Much of the knowledge you might gain from there will easily translate to this example contract.
+
+[Stellar Quest: Series 3, Quest 5]: https://quest.stellar.org/learn/series/3/quest/5
+
+### Interacting with Token Contracts in Another Contract
+
+#### Creating a Custom Token for LP Shares
 
 We are utilizing the compiled `token` example contract as our asset contract for
 the LP shares asset. This means it follows all the conventions of the Token
@@ -498,6 +567,8 @@ more. (Right?)
 {/* TODO: Why are we publishing the Token WASM code, instead of using the SDK
     built-in token stuff? Isn't that designed so we don't _have to_ deploy token
     WASM code and stuff? */}
+
+#### Token Transfers to/from the LP Contract
 
 ## Tests
 

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -743,7 +743,7 @@ when its own `get_rsvs` function is invoked.
 
 ## Tests
 
-Open the `/liquidity_pool/src/test.rs` file to follow along.
+Open the [`liquidity_pool/src/test.rs`] file to follow along.
 
 ```rust title=liquidity_pool/src/test.rs
 #![cfg(test)]
@@ -911,24 +911,74 @@ fn test() {
 }
 ```
 
+[`liquidity_pool/src/test.rs`]: https://github.com/stellar/soroban-examples/blob/v0.9.2/liquidity_pool/src/test.rs
+
 In any test the first thing that is always required is an `Env`, which is the
 Soroban environment that the contract will run in.
 
-```rust
+```rust title=liquidity_pool/src/test.rs
 let e = Env::default();
 ```
 
-The contract is registered with the environment using the contract type.
+We mock authentication checks in the tests, which allows the tests to proceed as
+if all users/addresses/contracts/etc. had successfully authenticated.
 
-```rust
-let contract_id = env.register_contract(None, IncrementContract);
+```rust title=liquidity_pool/src/test.rs
+e.mock_all_auths();
+```
+
+We have abstracted into a few functions the tasks of creating token contracts,
+deploying a liquidity pool contract, and installing the token example WASM
+bytecode into our test environment. Each are then used within the test.
+
+```rust title=liquidity_pool/src/test.rs
+fn create_token_contract<'a>(e: &Env, admin: &Address) -> token::Client<'a> {
+    token::Client::new(e, &e.register_stellar_asset_contract(admin.clone()))
+}
+
+fn create_liqpool_contract<'a>(
+    e: &Env,
+    token_wasm_hash: &BytesN<32>,
+    token_a: &Address,
+    token_b: &Address,
+) -> LiquidityPoolClient<'a> {
+    let liqpool = LiquidityPoolClient::new(e, &e.register_contract(None, crate::LiquidityPool {}));
+    liqpool.initialize(token_wasm_hash, token_a, token_b);
+    liqpool
+}
+
+fn install_token_wasm(e: &Env) -> BytesN<32> {
+    soroban_sdk::contractimport!(
+        file = "../token/target/wasm32-unknown-unknown/release/soroban_token_contract.wasm"
+    );
+    e.deployer().upload_contract_wasm(WASM)
+}
 ```
 
 All public functions within an `impl` block that is annotated with the
 `#[contractimpl]` attribute have a corresponding function generated in a
 generated client type. The client type will be named the same as the contract
 type with `Client` appended. For example, in our contract the contract type is
-`Contract`, and the client is named `ContractClient`.
+`LiquidityPool`, and the client is named `LiquidityPoolClient`.
+
+These tests examine the "typical" use-case of a liquidity pool, ensuring that
+the balances, returns, etc. are appropriate at various points during the test.
+
+1. First, the test sets everything up with an `Env`, two admin addresses, two
+   reserve tokens, a randomly generated address to act as the user of the
+   liquidity pool, the liquidity pool itself, a pool token shares contract, and
+   mints the reserve assets to the user address.
+2. The user then deposits some of each asset into the liquidity pool. At this
+   time, the following checks are done:
+   - appropriate authorizations for deposits and transfers exist,
+   - balances are checked for each token (`token_a`, `token_b`, and `POOL`) from
+     both the user's perspective and the `liqpool` contract's perspective
+3. The user performs a swap, buying `token_b` in exchange for `token_a`. The
+   same checks as the previous step are made now, excepting the balances of
+   `POOL`, since a swap has no effect on `POOL` tokens.
+4. The user then withdraws all of the deposits it made, trading all of its
+   `POOL` tokens in the process. The same checks are made here as were made in
+   the `deposit` step.
 
 ## Build the Contract
 

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -23,8 +23,671 @@ description: Write a constant-product liquidity pool contract.
 
 The [liquidity pool example] demonstrates how to write a constant product liquidity pool contract. The comments in the [source code] explain how the contract should be used.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.9.2
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
+
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v0.9.2
 [liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v0.9.2/liquidity_pool
 [source code]: https://github.com/stellar/soroban-examples/blob/v0.9.2/liquidity_pool/src/lib.rs#L143
+
+## Run the Example
+
+First go through the [Setup] process to get your development environment
+configured, then clone the `v0.9.2` tag of `soroban-examples` repository:
+
+```bash
+git clone -b v0.9.2 https://github.com/stellar/soroban-examples
+```
+
+Or, skip the development environment setup and open this example in
+[Gitpod][oigp].
+
+To run the tests for the example, navigate to the `liquidity_pool` directory,
+and use `cargo test`.
+
+```bash
+cd liquidity_pool
+cargo test
+```
+
+You should see the output:
+
+```bash
+running 1 test
+test test::test ... ok
+```
+
+[Setup]: ../getting-started/setup.mdx
+
+## Code
+
+:::note
+
+Since our liquidity pool will be issuing its own token to establish the nuber of
+shares in the pool the address has, we have created a `token.rs` module in this
+project to hold the logic for the token contract for those shares.
+
+:::
+
+<Tabs>
+<TabItem value="lib.rs" default>
+
+```rust title="liquidity_pool/src/lib.rs"
+#![no_std]
+
+mod test;
+mod token;
+
+use num_integer::Roots;
+use soroban_sdk::{
+    contract, contractimpl, contractmeta, Address, BytesN, ConversionError, Env, IntoVal,
+    TryFromVal, Val,
+};
+use token::create_contract;
+
+#[derive(Clone, Copy)]
+#[repr(u32)]
+pub enum DataKey {
+    TokenA = 0,
+    TokenB = 1,
+    TokenShare = 2,
+    TotalShares = 3,
+    ReserveA = 4,
+    ReserveB = 5,
+}
+
+impl TryFromVal<Env, DataKey> for Val {
+    type Error = ConversionError;
+
+    fn try_from_val(_env: &Env, v: &DataKey) -> Result<Self, Self::Error> {
+        Ok((*v as u32).into())
+    }
+}
+
+fn get_token_a(e: &Env) -> Address {
+    e.storage().instance().get(&DataKey::TokenA).unwrap()
+}
+
+fn get_token_b(e: &Env) -> Address {
+    e.storage().instance().get(&DataKey::TokenB).unwrap()
+}
+
+fn get_token_share(e: &Env) -> Address {
+    e.storage().instance().get(&DataKey::TokenShare).unwrap()
+}
+
+fn get_total_shares(e: &Env) -> i128 {
+    e.storage().instance().get(&DataKey::TotalShares).unwrap()
+}
+
+fn get_reserve_a(e: &Env) -> i128 {
+    e.storage().instance().get(&DataKey::ReserveA).unwrap()
+}
+
+fn get_reserve_b(e: &Env) -> i128 {
+    e.storage().instance().get(&DataKey::ReserveB).unwrap()
+}
+
+fn get_balance(e: &Env, contract: Address) -> i128 {
+    token::Client::new(e, &contract).balance(&e.current_contract_address())
+}
+
+fn get_balance_a(e: &Env) -> i128 {
+    get_balance(e, get_token_a(e))
+}
+
+fn get_balance_b(e: &Env) -> i128 {
+    get_balance(e, get_token_b(e))
+}
+
+fn get_balance_shares(e: &Env) -> i128 {
+    get_balance(e, get_token_share(e))
+}
+
+fn put_token_a(e: &Env, contract: Address) {
+    e.storage().instance().set(&DataKey::TokenA, &contract);
+}
+
+fn put_token_b(e: &Env, contract: Address) {
+    e.storage().instance().set(&DataKey::TokenB, &contract);
+}
+
+fn put_token_share(e: &Env, contract: Address) {
+    e.storage().instance().set(&DataKey::TokenShare, &contract);
+}
+
+fn put_total_shares(e: &Env, amount: i128) {
+    e.storage().instance().set(&DataKey::TotalShares, &amount)
+}
+
+fn put_reserve_a(e: &Env, amount: i128) {
+    e.storage().instance().set(&DataKey::ReserveA, &amount)
+}
+
+fn put_reserve_b(e: &Env, amount: i128) {
+    e.storage().instance().set(&DataKey::ReserveB, &amount)
+}
+
+fn burn_shares(e: &Env, amount: i128) {
+    let total = get_total_shares(e);
+    let share_contract = get_token_share(e);
+
+    token::Client::new(e, &share_contract).burn(&e.current_contract_address(), &amount);
+    put_total_shares(e, total - amount);
+}
+
+fn mint_shares(e: &Env, to: Address, amount: i128) {
+    let total = get_total_shares(e);
+    let share_contract_id = get_token_share(e);
+
+    token::Client::new(e, &share_contract_id).mint(&to, &amount);
+
+    put_total_shares(e, total + amount);
+}
+
+fn transfer(e: &Env, token: Address, to: Address, amount: i128) {
+    token::Client::new(e, &token).transfer(&e.current_contract_address(), &to, &amount);
+}
+
+fn transfer_a(e: &Env, to: Address, amount: i128) {
+    transfer(e, get_token_a(e), to, amount);
+}
+
+fn transfer_b(e: &Env, to: Address, amount: i128) {
+    transfer(e, get_token_b(e), to, amount);
+}
+
+fn get_deposit_amounts(
+    desired_a: i128,
+    min_a: i128,
+    desired_b: i128,
+    min_b: i128,
+    reserve_a: i128,
+    reserve_b: i128,
+) -> (i128, i128) {
+    if reserve_a == 0 && reserve_b == 0 {
+        return (desired_a, desired_b);
+    }
+
+    let amount_b = desired_a * reserve_b / reserve_a;
+    if amount_b <= desired_b {
+        if amount_b < min_b {
+            panic!("amount_b less than min")
+        }
+        (desired_a, amount_b)
+    } else {
+        let amount_a = desired_b * reserve_a / reserve_b;
+        if amount_a > desired_a || desired_a < min_a {
+            panic!("amount_a invalid")
+        }
+        (amount_a, desired_b)
+    }
+}
+
+// Metadata that is added on to the WASM custom section
+contractmeta!(
+    key = "Description",
+    val = "Constant product AMM with a .3% swap fee"
+);
+
+pub trait LiquidityPoolTrait {
+    // Sets the token contract addresses for this pool
+    fn initialize(e: Env, token_wasm_hash: BytesN<32>, token_a: Address, token_b: Address);
+
+    // Returns the token contract address for the pool share token
+    fn share_id(e: Env) -> Address;
+
+    // Deposits token_a and token_b. Also mints pool shares for the "to" Identifier. The amount minted
+    // is determined based on the difference between the reserves stored by this contract, and
+    // the actual balance of token_a and token_b for this contract.
+    fn deposit(e: Env, to: Address, desired_a: i128, min_a: i128, desired_b: i128, min_b: i128);
+
+    // If "buy_a" is true, the swap will buy token_a and sell token_b. This is flipped if "buy_a" is false.
+    // "out" is the amount being bought, with in_max being a safety to make sure you receive at least that amount.
+    // swap will transfer the selling token "to" to this contract, and then the contract will transfer the buying token to "to".
+    fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128);
+
+    // transfers share_amount of pool share tokens to this contract, burns all pools share tokens in this contracts, and sends the
+    // corresponding amount of token_a and token_b to "to".
+    // Returns amount of both tokens withdrawn
+    fn withdraw(e: Env, to: Address, share_amount: i128, min_a: i128, min_b: i128) -> (i128, i128);
+
+    fn get_rsrvs(e: Env) -> (i128, i128);
+}
+
+#[contract]
+struct LiquidityPool;
+
+#[contractimpl]
+impl LiquidityPoolTrait for LiquidityPool {
+    fn initialize(e: Env, token_wasm_hash: BytesN<32>, token_a: Address, token_b: Address) {
+        if token_a >= token_b {
+            panic!("token_a must be less than token_b");
+        }
+
+        let share_contract = create_contract(&e, token_wasm_hash, &token_a, &token_b);
+        token::Client::new(&e, &share_contract).initialize(
+            &e.current_contract_address(),
+            &7u32,
+            &"Pool Share Token".into_val(&e),
+            &"POOL".into_val(&e),
+        );
+
+        put_token_a(&e, token_a);
+        put_token_b(&e, token_b);
+        put_token_share(&e, share_contract.try_into().unwrap());
+        put_total_shares(&e, 0);
+        put_reserve_a(&e, 0);
+        put_reserve_b(&e, 0);
+    }
+
+    fn share_id(e: Env) -> Address {
+        get_token_share(&e)
+    }
+
+    fn deposit(e: Env, to: Address, desired_a: i128, min_a: i128, desired_b: i128, min_b: i128) {
+        // Depositor needs to authorize the deposit
+        to.require_auth();
+
+        let (reserve_a, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
+
+        // Calculate deposit amounts
+        let amounts = get_deposit_amounts(desired_a, min_a, desired_b, min_b, reserve_a, reserve_b);
+
+        let token_a_client = token::Client::new(&e, &get_token_a(&e));
+        let token_b_client = token::Client::new(&e, &get_token_b(&e));
+
+        token_a_client.transfer(&to, &e.current_contract_address(), &amounts.0);
+        token_b_client.transfer(&to, &e.current_contract_address(), &amounts.1);
+
+        // Now calculate how many new pool shares to mint
+        let (balance_a, balance_b) = (get_balance_a(&e), get_balance_b(&e));
+        let total_shares = get_total_shares(&e);
+
+        let zero = 0;
+        let new_total_shares = if reserve_a > zero && reserve_b > zero {
+            let shares_a = (balance_a * total_shares) / reserve_a;
+            let shares_b = (balance_b * total_shares) / reserve_b;
+            shares_a.min(shares_b)
+        } else {
+            (balance_a * balance_b).sqrt()
+        };
+
+        mint_shares(&e, to, new_total_shares - total_shares);
+        put_reserve_a(&e, balance_a);
+        put_reserve_b(&e, balance_b);
+    }
+
+    fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128) {
+        to.require_auth();
+
+        let (reserve_a, reserve_b) = (get_reserve_a(&e), get_reserve_b(&e));
+        let (reserve_sell, reserve_buy) = if buy_a {
+            (reserve_b, reserve_a)
+        } else {
+            (reserve_a, reserve_b)
+        };
+
+        // First calculate how much needs to be sold to buy amount out from the pool
+        let n = reserve_sell * out * 1000;
+        let d = (reserve_buy - out) * 997;
+        let sell_amount = (n / d) + 1;
+        if sell_amount > in_max {
+            panic!("in amount is over max")
+        }
+
+        // Transfer the amount being sold to the contract
+        let sell_token = if buy_a {
+            get_token_b(&e)
+        } else {
+            get_token_a(&e)
+        };
+        let sell_token_client = token::Client::new(&e, &sell_token);
+        sell_token_client.transfer(&to, &e.current_contract_address(), &sell_amount);
+
+        let (balance_a, balance_b) = (get_balance_a(&e), get_balance_b(&e));
+
+        // residue_numerator and residue_denominator are the amount that the invariant considers after
+        // deducting the fee, scaled up by 1000 to avoid fractions
+        let residue_numerator = 997;
+        let residue_denominator = 1000;
+        let zero = 0;
+
+        let new_invariant_factor = |balance: i128, reserve: i128, out: i128| {
+            let delta = balance - reserve - out;
+            let adj_delta = if delta > zero {
+                residue_numerator * delta
+            } else {
+                residue_denominator * delta
+            };
+            residue_denominator * reserve + adj_delta
+        };
+
+        let (out_a, out_b) = if buy_a { (out, 0) } else { (0, out) };
+
+        let new_inv_a = new_invariant_factor(balance_a, reserve_a, out_a);
+        let new_inv_b = new_invariant_factor(balance_b, reserve_b, out_b);
+        let old_inv_a = residue_denominator * reserve_a;
+        let old_inv_b = residue_denominator * reserve_b;
+
+        if new_inv_a * new_inv_b < old_inv_a * old_inv_b {
+            panic!("constant product invariant does not hold");
+        }
+
+        if buy_a {
+            transfer_a(&e, to, out_a);
+        } else {
+            transfer_b(&e, to, out_b);
+        }
+
+        put_reserve_a(&e, balance_a - out_a);
+        put_reserve_b(&e, balance_b - out_b);
+    }
+
+    fn withdraw(e: Env, to: Address, share_amount: i128, min_a: i128, min_b: i128) -> (i128, i128) {
+        to.require_auth();
+
+        // First transfer the pool shares that need to be redeemed
+        let share_token_client = token::Client::new(&e, &get_token_share(&e));
+        share_token_client.transfer(&to, &e.current_contract_address(), &share_amount);
+
+        let (balance_a, balance_b) = (get_balance_a(&e), get_balance_b(&e));
+        let balance_shares = get_balance_shares(&e);
+
+        let total_shares = get_total_shares(&e);
+
+        // Now calculate the withdraw amounts
+        let out_a = (balance_a * balance_shares) / total_shares;
+        let out_b = (balance_b * balance_shares) / total_shares;
+
+        if out_a < min_a || out_b <TabItem min_b {
+            panic!("min not satisfied");
+        }
+
+        burn_shares(&e, balance_shares);
+        transfer_a(&e, to.clone(), out_a);
+        transfer_b(&e, to, out_b);
+        put_reserve_a(&e, balance_a - out_a);
+        put_reserve_b(&e, balance_b - out_b);
+
+        (out_a, out_b)
+    }
+
+    fn get_rsrvs(e: Env) -> (i128, i128) {
+        (get_reserve_a(&e), get_reserve_b(&e))
+    }
+}
+```
+
+</TabItem>
+<TabItem value="token.rs">
+
+```rust title="liquidity_pool/src/token.rs"
+#![allow(unused)]
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
+
+soroban_sdk::contractimport!(
+    file = "../token/target/wasm32-unknown-unknown/release/soroban_token_contract.wasm"
+);
+
+pub fn create_contract(
+    e: &Env,
+    token_wasm_hash: BytesN<32>,
+    token_a: &Address,
+    token_b: &Address,
+) -> Address {
+    let mut salt = Bytes::new(e);
+    salt.append(&token_a.to_xdr(e));
+    salt.append(&token_b.to_xdr(e));
+    let salt = e.crypto().sha256(&salt);
+    e.deployer()
+        .with_current_contract(salt)
+        .deploy(token_wasm_hash)
+}
+```
+
+</TabItem>
+</Tabs>
+
+Ref: https://github.com/stellar/soroban-examples/tree/v0.9.2/liquidity_pool
+
+## How it Works
+
+Something about how it works
+
+### Main Idea 1
+
+Something about this main idea
+
+### Main Idea 2
+
+Something about this main idea
+
+### Main Idea 3
+
+Something about this main idea
+
+## Tests
+
+Open the `/liquidity_pool/src/test.rs` file to follow along.
+
+```rust title="/liquidity_pool/src/test.rs"
+#![cfg(test)]
+extern crate std;
+
+use crate::{token, LiquidityPoolClient};
+
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    Address, BytesN, Env, IntoVal,
+};
+
+fn create_token_contract<'a>(e: &Env, admin: &Address) -> token::Client<'a> {
+    token::Client::new(e, &e.register_stellar_asset_contract(admin.clone()))
+}
+
+fn create_liqpool_contract<'a>(
+    e: &Env,
+    token_wasm_hash: &BytesN<32>,
+    token_a: &Address,
+    token_b: &Address,
+) -> LiquidityPoolClient<'a> {
+    let liqpool = LiquidityPoolClient::new(e, &e.register_contract(None, crate::LiquidityPool {}));
+    liqpool.initialize(token_wasm_hash, token_a, token_b);
+    liqpool
+}
+
+fn install_token_wasm(e: &Env) -> BytesN<32> {
+    soroban_sdk::contractimport!(
+        file = "../token/target/wasm32-unknown-unknown/release/soroban_token_contract.wasm"
+    );
+    e.deployer().upload_contract_wasm(WASM)
+}
+
+#[test]
+fn test() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let mut admin1 = Address::random(&e);
+    let mut admin2 = Address::random(&e);
+
+    let mut token1 = create_token_contract(&e, &admin1);
+    let mut token2 = create_token_contract(&e, &admin2);
+    if &token2.address < &token1.address {
+        std::mem::swap(&mut token1, &mut token2);
+        std::mem::swap(&mut admin1, &mut admin2);
+    }
+    let user1 = Address::random(&e);
+    let liqpool = create_liqpool_contract(
+        &e,
+        &install_token_wasm(&e),
+        &token1.address,
+        &token2.address,
+    );
+
+    let token_share = token::Client::new(&e, &liqpool.share_id());
+
+    token1.mint(&user1, &1000);
+    assert_eq!(token1.balance(&user1), 1000);
+
+    token2.mint(&user1, &1000);
+    assert_eq!(token2.balance(&user1), 1000);
+
+    liqpool.deposit(&user1, &100, &100, &100, &100);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    liqpool.address.clone(),
+                    symbol_short!("deposit"),
+                    (&user1, 100_i128, 100_i128, 100_i128, 100_i128).into_val(&e)
+                )),
+                sub_invocations: std::vec![
+                    AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            token1.address.clone(),
+                            symbol_short!("transfer"),
+                            (&user1, &liqpool.address, 100_i128).into_val(&e)
+                        )),
+                        sub_invocations: std::vec![]
+                    },
+                    AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            token2.address.clone(),
+                            symbol_short!("transfer"),
+                            (&user1, &liqpool.address, 100_i128).into_val(&e)
+                        )),
+                        sub_invocations: std::vec![]
+                    }
+                ]
+            }
+        )]
+    );
+
+    assert_eq!(token_share.balance(&user1), 100);
+    assert_eq!(token_share.balance(&liqpool.address), 0);
+    assert_eq!(token1.balance(&user1), 900);
+    assert_eq!(token1.balance(&liqpool.address), 100);
+    assert_eq!(token2.balance(&user1), 900);
+    assert_eq!(token2.balance(&liqpool.address), 100);
+
+    liqpool.swap(&user1, &false, &49, &100);
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    liqpool.address.clone(),
+                    symbol_short!("swap"),
+                    (&user1, false, 49_i128, 100_i128).into_val(&e)
+                )),
+                sub_invocations: std::vec![AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        token1.address.clone(),
+                        symbol_short!("transfer"),
+                        (&user1, &liqpool.address, 97_i128).into_val(&e)
+                    )),
+                    sub_invocations: std::vec![]
+                }]
+            }
+        )]
+    );
+
+    assert_eq!(token1.balance(&user1), 803);
+    assert_eq!(token1.balance(&liqpool.address), 197);
+    assert_eq!(token2.balance(&user1), 949);
+    assert_eq!(token2.balance(&liqpool.address), 51);
+
+    e.budget().reset_unlimited();
+    liqpool.withdraw(&user1, &100, &197, &51);
+
+    assert_eq!(
+        e.auths(),
+        std::vec![(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    liqpool.address.clone(),
+                    symbol_short!("withdraw"),
+                    (&user1, 100_i128, 197_i128, 51_i128).into_val(&e)
+                )),
+                sub_invocations: std::vec![AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        token_share.address.clone(),
+                        symbol_short!("transfer"),
+                        (&user1, &liqpool.address, 100_i128).into_val(&e)
+                    )),
+                    sub_invocations: std::vec![]
+                }]
+            }
+        )]
+    );
+
+    assert_eq!(token1.balance(&user1), 1000);
+    assert_eq!(token2.balance(&user1), 1000);
+    assert_eq!(token_share.balance(&user1), 0);
+    assert_eq!(token1.balance(&liqpool.address), 0);
+    assert_eq!(token2.balance(&liqpool.address), 0);
+    assert_eq!(token_share.balance(&liqpool.address), 0);
+}
+```
+
+In any test the first thing that is always required is an `Env`, which is the
+Soroban environment that the contract will run in.
+
+```rust
+let e = Env::default();
+```
+
+The contract is registered with the environment using the contract type.
+
+```rust
+let contract_id = env.register_contract(None, IncrementContract);
+```
+
+All public functions within an `impl` block that is annotated with the
+`#[contractimpl]` attribute have a corresponding function generated in a
+generated client type. The client type will be named the same as the contract
+type with `Client` appended. For example, in our contract the contract type is
+`Contract`, and the client is named `ContractClient`.
+
+## Build the Contract
+
+To build the contract, use the `soroban contract build` command.
+
+```bash
+soroban contract build
+```
+
+A `.wasm` file should be outputted in the `target` directory:
+
+```bash
+target/wasm32-unknown-unknown/release/soroban_liquidity_pool_contract.wasm
+```
+
+## Run the Contract
+
+If you have [`soroban-cli`] installed, you can invoke contract functions using
+it.
+
+```bash
+soroban contract invoke \
+    --wasm target/wasm32-unknown-unknown/release/soroban_liquidity_pool_contract.wasm \
+    --id 1 \
+    -- \
+    deposit \
+    --to GBZV3NONYSUDVTEHATQO4BCJVFXJO3XQU5K32X3XREVZKSMMOZFO4ZXR \
+    --desired_a 100 \
+    --min_a 98 \
+    --desired_be 200 \
+    --min_b 196 \
+```
+
+[`soroban-cli`]: ../reference/soroban-cli

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -37,9 +37,14 @@ built-in Stellar AMM liquidity pools.
 
 :::caution
 
-Implementing a custom liquidity pool should be done cautiously. User funds are involved, so great care should be taken to ensure safety and transparency. The example here should _not_ be considered a ready-to-go contract. Please use it as a reference only.
+Implementing a custom liquidity pool should be done cautiously. User funds are
+involved, so great care should be taken to ensure safety and transparency. The
+example here should _not_ be considered a ready-to-go contract. Please use it as
+a reference only.
 
-The Stellar network already has liquidity pool functionality built right in to the core protocol. [Learn more here.](https://developers.stellar.org/docs/encyclopedia/liquidity-on-stellar-sdex-liquidity-pools)
+The Stellar network already has liquidity pool functionality built right in to
+the core protocol. [Learn more
+here.](https://developers.stellar.org/docs/encyclopedia/liquidity-on-stellar-sdex-liquidity-pools)
 
 :::
 
@@ -91,7 +96,7 @@ project to hold the logic controlling the token contract for those shares.
 <Tabs>
 <TabItem value="lib.rs" default>
 
-```rust title="liquidity_pool/src/lib.rs"
+```rust title=liquidity_pool/src/lib.rs
 #![no_std]
 
 mod test;
@@ -441,7 +446,7 @@ impl LiquidityPoolTrait for LiquidityPool {
 </TabItem>
 <TabItem value="token.rs">
 
-```rust title="liquidity_pool/src/token.rs"
+```rust title=liquidity_pool/src/token.rs
 #![allow(unused)]
 use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
 
@@ -495,18 +500,21 @@ following information:
   token] as well as [interacting with contracts for `token_a` and `token_b`].
   The way this example works is by using the [`token` example contract] for both
   of these jobs. When our liquidity pool contract is initialized it wants us to
-  pass the wasm hash of the **already deployed** token contract. It will then
-  re-deploy the WASM bytecode that is stored at that hash into a new token
-  contract for the `POOL` tokens.
+  pass the wasm hash of the **already [installed]** token contract. It will then
+  deploy a contract that will run the WASM bytecode stored at that hash as a new
+  token contract for the `POOL` tokens.
 - **`token_a`:** The contract `Address` for an **already deployed** (or wrapped)
   token that will be held in reserve by the liquidity pool.
 - **`token_b`:** The contract `Address` for an **already deployed** (or wrapped)
   token that will be held in reserve by the liquidity pool.
 
-Bear in mind that which token is `token_a` and which is `token_b` isn't arbitrary.
-In line with the Built-in Stellar liquidity pools, this contract can only make a single liquidity pool for a given set of tokens. So, the token addresses must be provided in [lexicographical order] at initialization.
+Bear in mind that which token is `token_a` and which is `token_b` is **not** an
+arbitrary distinction. In line with the Built-in Stellar liquidity pools, this
+contract can only make a single liquidity pool for a given set of tokens. So,
+the token addresses must be provided in [lexicographical order] at the time of
+initialization.
 
-```rust
+```rust title=liquidity_pool/src/lib.rs
 fn initialize(e: Env, token_wasm_hash: BytesN<32>, taken_a: Address, token_b: Address) {
     if token_a >= token_b {
         panic!("token_a must be less than token_b");
@@ -525,19 +533,29 @@ fn initialize(e: Env, token_wasm_hash: BytesN<32>, taken_a: Address, token_b: Ad
 [creating its own `POOL` token]: #creating-a-custom-token-for-lp-shares
 [interacting with contracts for `token_a` and `token_b`]: #token-transfers-tofrom-the-lp-contract
 [`token` example contract]: ./tokens
+[installed]: ../getting-started/deploy-to-futurenet#two-step-deployment
 [lexicographical order]: https://developers.stellar.org/docs/encyclopedia/liquidity-on-stellar-sdex-liquidity-pools#liquidity-pool-participation
-
-### Make a First Deposit
 
 ### A "Constant Product" Liquidity Pool
 
-The _type_ of liquidity pool this example contract implements is called a "constant product" liquidity pool. While this isn't the only type of liquidity pool out there, it is the most common variety. These liquidity pools are designed to keep the _total_ value of each asset in _relative_ equilibrium. The "product" in the constant product (also called an "invariant") will change every time the liquidity pool is interacted with (deposit, withdraw, or token swaps). However, the invariant **must** only increase with every interaction.
+The _type_ of liquidity pool this example contract implements is called a
+"constant product" liquidity pool. While this isn't the only type of liquidity
+pool out there, it is the most common variety. These liquidity pools are
+designed to keep the _total_ value of each asset in _relative_ equilibrium. The
+"product" in the constant product (also called an "invariant") will change every
+time the liquidity pool is interacted with (deposit, withdraw, or token swaps).
+However, the invariant **must** only increase with every interaction.
 
-During a swap, what must be kept in mind is that for every withdrawal from the `token_a` side, you must "refill" the `token_b` side with a sufficient amount to keep the liquidity pool's price balanced. The math is predictable, but it is not linear. The more you take from one side, the more you must give on the opposite site _exponentially_.
+During a swap, what must be kept in mind is that for every withdrawal from the
+`token_a` side, you must "refill" the `token_b` side with a sufficient amount to
+keep the liquidity pool's price balanced. The math is predictable, but it is not
+linear. The more you take from one side, the more you must give on the opposite
+site _exponentially_.
 
-Inside the `swap` function, the math is done like this (this is a simplified version, however):
+Inside the `swap` function, the math is done like this (this is a simplified
+version, however):
 
-```rust
+```rust title=liquidity_pool/src/lib.rs
 fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128) {
     // Get the current balances of both tokens in the liquidity pool
     let (reserve_sell, reserve_buy) = (get_reserve_a(&e), get_reserve_b(&e));
@@ -549,32 +567,185 @@ fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128) {
 }
 ```
 
-We have much more in-depth information about how this kind of liquidity pool works is available in [Stellar Quest: Series 3, Quest 5]. This is a really useful, interactive way to learn more about how the built-in Stellar liquidity pools work. Much of the knowledge you might gain from there will easily translate to this example contract.
+We have much more in-depth information about how this kind of liquidity pool
+works is available in [Stellar Quest: Series 3, Quest 5]. This is a really
+useful, interactive way to learn more about how the built-in Stellar liquidity
+pools work. Much of the knowledge you might gain from there will easily
+translate to this example contract.
 
 [Stellar Quest: Series 3, Quest 5]: https://quest.stellar.org/learn/series/3/quest/5
 
 ### Interacting with Token Contracts in Another Contract
 
-#### Creating a Custom Token for LP Shares
+This liquidity pool contract will operate with a total of three different
+Soroban tokens:
+
+- **`POOL`:** This token is a unique token that is given to asset depositors in
+  exchange for their deposit. These tokens are "traded in" by the user when they
+  withdraw some amount of their original deposit (plus any earned swap fees).
+  This example contract implements the same [`token` example contract] for this
+  token.
+- **`token_a`**  and **`token_b`**: Will be the two "reserve tokens" that users
+  will deposit into the pool. These could be "wrapped" tokens from pre-existing
+  Stellar assets, or they could be Soroban-native tokens. This contract doesn't
+  really care, as long as the functions it needs from the common [Token
+  Interface] are available in the token contract.
+
+[Token Interface]: ../reference/interfaces/token-interface
+
+#### Creating a Custom `POOL` Token for LP Shares
 
 We are utilizing the compiled `token` example contract as our asset contract for
-the LP shares asset. This means it follows all the conventions of the Token
-Interface, and can be treated just like any other token. They could be
+the `POOL` token. This means it follows all the conventions of the [Token
+Interface], and can be treated just like any other token. They could be
 transferred, burned, minted, etc. It also means the LP developer _could_ take
 advantage of the administrative features such as clawbacks, authorization, and
-more. (Right?)
+more.
 
-{/* TODO: Why are we publishing the Token WASM code, instead of using the SDK
-    built-in token stuff? Isn't that designed so we don't _have to_ deploy token
-    WASM code and stuff? */}
+The `token.rs` file contains a `create_contract` function that we will use to
+deploy this particular token contract.
+
+```rust title="src/token.rs"
+pub fn create_contract(
+    e: &Env,
+    token_wasm_hash: BytesN<32>,
+    token_a: &Address,
+    token_b: &Address,
+) -> Address {
+    let mut salt = Bytes::new(e);
+    salt.append(&token_a.to_xdr(e));
+    salt.append(&token_b.to_xdr(e));
+    let salt = e.crypto().sha256(&salt);
+    e.deployer()
+        .with_current_contract(salt)
+        .deploy(token_wasm_hash)
+}
+```
+
+This `POOL` token contract is then created within the `initialize` function.
+
+```rust title=liquidity_pool/src/lib.rs
+fn initialize(e: Env, token_wasm_hash: BytesN<32>, token_a: Address, token_b: Address) {
+    let share_contract = create_contract(&e, token_wasm_hash, &token_a, &token_b);
+    token::Client::new(&e, &share_contract).initialize(
+        &e.current_contract_address(),
+        &7u32,
+        &"Pool Share Token".into_val(&e),
+        &"POOL".into_val(&e),
+    );
+}
+```
+
+Then, during a `deposit`, a calculated amount of `POOL` tokens are `mint`ed to
+the depositing address.
+
+```rust title=liquidity_pool/src/lib.rs
+fn mint_shares(e: &Env, to: Address, amount: i128) {
+    let total = get_total_shares(e);
+    let share_contract_id = get_token_share(e);
+
+    token::Client::new(e, &share_contract_id).mint(&to, &amount);
+
+    put_total_shares(e, total + amount);
+}
+```
+
+How is that number of shares calculated, you ask? Excellent question! If it's
+the very first deposit (see above), it's just the square root of the product of
+the quantities of `token_a` and `token_b` deposited. Very simple.
+
+However, if there have already been deposits into the liquidity pool, and the
+user is just adding more tokens into the pool, there's a bit more math. However,
+the main point is that each depositor receives the same ratio of `POOL` tokens
+for their deposit as every other depositor.
+
+```rust title=liquidity_pool/src/lib.rs
+fn deposit(e: Env, to: Address, desired_a: i128, min_a: i128, desired_b: i128, min_b: i128) {
+    let zero = 0;
+    let new_total_shares = if reserve_a > zero && reserve_b > zero {
+        // Note balance_a and balance_b at this point in the function include
+        // the tokens the user is currently depositing, whereas reserve_a and
+        // reserve_b do not yet.
+        let shares_a = (balance_a * total_shares) / reserve_a;
+        let shares_b = (balance_b * total_shares) / reserve_b;
+        shares_a.min(shares_b)
+    } else {
+        (balance_a * balance_b).sqrt()
+    };
+}
+```
 
 #### Token Transfers to/from the LP Contract
+
+As we've already discussed, the liquidity pool contract will make use of the
+[Token Interface] available in the token contracts that were supplied as
+`token_a` and `token_b` arguments at the time of initialization. Throughout the
+rest of the contract, the liquidity pool will make use of that interface to make
+transfers of those tokens to/from itself.
+
+What's happening is that as a user deposits tokens into the pool, and the
+contract invokes the `transfer` function to move the tokens from the `to`
+address (the depositor) to be held by the contract address. `POOL` tokens are
+then minted to depositor (see previous section). Pretty simple, right!?
+
+```rust title=liquidity_pool/src/lib.rs
+fn deposit(e: Env, to: Address, desired_a: i128, min_a: i128, desired_b: i128, min_b: i128) {
+    // Depositor needs to authorize the deposit
+    to.require_auth();
+
+    let token_a_client = token::Client::new(&e, &get_token_a(&e));
+    let token_b_client = token::Client::new(&e, &get_token_b(&e));
+
+    token_a_client.transfer(&to, &e.current_contract_address(), &amounts.0);
+    token_b_client.transfer(&to, &e.current_contract_address(), &amounts.1);
+
+    mint_shares(&e, to, new_total_shares - total_shares);
+}
+```
+
+In contrast, when a user withdraws their deposited tokens, It's about more
+involved, and the following procedure happens.
+
+1. Some amount of the `POOL` token is transferred from the depositor to the
+   contract address. This is a temporary way to track how many `POOL` tokens are
+   being redeemed. The contract will not hold this balance of `POOL` for long.
+2. The withdraw amounts for the reserve tokens are calculated based on the
+   contract's current balance of `POOL` tokens.
+3. The `POOL` tokens are burned now that the withdraw amounts have been
+   calculated, and they are no longer needed.
+3. The respective amounts of `token_a` and `token_b` are transferred _from_ the
+   contract address into the `to` address (the depositor).
+
+```rust title=liquidity_pool/src/lib.rs
+fn withdraw(e: Env, to: Address, share_amount: i128, min_a: i128, min_b: i128) -> (i128, i128) {
+    to.require_auth();
+
+    // First transfer the pool shares that need to be redeemed
+    let share_token_client = token::Client::new(&e, &get_token_share(&e));
+    share_token_client.transfer(&to, &e.current_contract_address(), &share_amount);
+
+    // Now calculate the withdraw amounts
+    let out_a = (balance_a * balance_shares) / total_shares;
+    let out_b = (balance_b * balance_shares) / total_shares;
+
+    burn_shares(&e, balance_shares);
+    transfer_a(&e, to.clone(), out_a);
+    transfer_b(&e, to, out_b);
+}
+```
+
+You'll notice that by holding the balance of `token_a` and `token_b` on the
+liquidity pool contract itself it makes, it very easy for us to perform any of
+the [Token Interface] actions inside the contract. As a bonus, any outside
+observer could query the balances of `token_a` or `token_b` held by the contract
+to verify the reserves are actually in line with the values the contract reports
+when its own `get_rsvs` function is invoked.
 
 ## Tests
 
 Open the `/liquidity_pool/src/test.rs` file to follow along.
 
-```rust title="/liquidity_pool/src/test.rs"
+```rust title=liquidity_pool/src/test.rs
 #![cfg(test)]
 extern crate std;
 

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -21,10 +21,27 @@ description: Write a constant-product liquidity pool contract.
   />
 </head>
 
-The [liquidity pool example] demonstrates how to write a constant product liquidity pool contract. The comments in the [source code] explain how the contract should be used.
-
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+
+The [liquidity pool example] demonstrates how to write a constant product
+liquidity pool contract. A liquidity pool is an automated way to add liquidity
+for a set of tokens that will facilitate asset conversion between them. Users
+can deposit some amount of each token into the pool, receiving a proportional
+number of "token shares." The user will then receive a portion of the accrued
+conversion fees when they ultimately "trade in" their token shares to receive
+their original tokens back.
+
+Soroban liquidity pools are exclusive to Soroban and cannot interact with
+built-in Stellar AMM liquidity pools.
+
+:::caution
+
+Implementing a custom liquidity pool should be done cautiously. User funds are involved, so great care should be taken to ensure safety and transparency. The example here should _not_ be considered a ready-to-go contract. Please use it as a reference only.
+
+The Stellar network already has liquidity pool functionality built right in to the core protocol. [Learn more here.](https://developers.stellar.org/docs/encyclopedia/liquidity-on-stellar-sdex-liquidity-pools)
+
+:::
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
@@ -63,11 +80,11 @@ test test::test ... ok
 
 ## Code
 
-:::note
+:::info
 
 Since our liquidity pool will be issuing its own token to establish the nuber of
 shares in the pool the address has, we have created a `token.rs` module in this
-project to hold the logic for the token contract for those shares.
+project to hold the logic controlling the token contract for those shares.
 
 :::
 
@@ -457,17 +474,30 @@ Ref: https://github.com/stellar/soroban-examples/tree/v0.9.2/liquidity_pool
 
 Something about how it works
 
-### Main Idea 1
+### A "Constant Product" Liquidity Pool
 
-Something about this main idea
+We should describe how this is a "constant product" LP, and (briefly) what other
+kinds of LPs exist. We could even go into the **fascinating** math behind how
+the "constant product" and fees are figured.
 
-### Main Idea 2
+### Contract Metadata
 
-Something about this main idea
+This is (I believe) the only example contract that is making use of the
+`contractmeta!()` macro. We should talk about what that does, and how it can be
+useful.
 
-### Main Idea 3
+### Creating a Custom Token for LP Shares
 
-Something about this main idea
+We are utilizing the compiled `token` example contract as our asset contract for
+the LP shares asset. This means it follows all the conventions of the Token
+Interface, and can be treated just like any other token. They could be
+transferred, burned, minted, etc. It also means the LP developer _could_ take
+advantage of the administrative features such as clawbacks, authorization, and
+more. (Right?)
+
+{/* TODO: Why are we publishing the Token WASM code, instead of using the SDK
+    built-in token stuff? Isn't that designed so we don't _have to_ deploy token
+    WASM code and stuff? */}
 
 ## Tests
 

--- a/docs/advanced-tutorials/liquidity-pool.mdx
+++ b/docs/advanced-tutorials/liquidity-pool.mdx
@@ -585,7 +585,7 @@ Soroban tokens:
   withdraw some amount of their original deposit (plus any earned swap fees).
   This example contract implements the same [`token` example contract] for this
   token.
-- **`token_a`**  and **`token_b`**: Will be the two "reserve tokens" that users
+- **`token_a`** and **`token_b`**: Will be the two "reserve tokens" that users
   will deposit into the pool. These could be "wrapped" tokens from pre-existing
   Stellar assets, or they could be Soroban-native tokens. This contract doesn't
   really care, as long as the functions it needs from the common [Token
@@ -713,7 +713,7 @@ involved, and the following procedure happens.
    contract's current balance of `POOL` tokens.
 3. The `POOL` tokens are burned now that the withdraw amounts have been
    calculated, and they are no longer needed.
-3. The respective amounts of `token_a` and `token_b` are transferred _from_ the
+4. The respective amounts of `token_a` and `token_b` are transferred _from_ the
    contract address into the `to` address (the depositor).
 
 ```rust title=liquidity_pool/src/lib.rs


### PR DESCRIPTION
The LP tutorial currently just points to the example contract codebase, and provides no additional content/context for what is happening within the contract.

This change adds content in the form of a written guide that describes what is happening in the example contract and a few additional pieces of context/information that could be useful/helpful for developers as they write their own contracts.

A couple minor additional changes in this PR:

- A `TUTORIAL-TEMPLATE.mdx` file that can be copied/pasted for new tutorial guides
- Some minor markdown fixes/nitpicks in a couple other files.