### PR TITLE
Update soroban-rpc docs

### DIFF
--- a/api/methods/simulateTransaction.mdx
+++ b/api/methods/simulateTransaction.mdx
@@ -10,17 +10,20 @@ Submit a trial contract invocation to simulate how it would be executed by the n
 ## Returns
 
 - `<object>`
-  - `minResourceFee`: `<string>` - Stringified-number of the recommended minimum resource fee to add when submitting the transaction. This fee is to be added on top of the [Stellar network fee](https://developers.stellar.org/docs/encyclopedia/fees-surge-pricing-fee-strategies#network-fees-on-stellar). 
-  - `cost`: `<object>` - Information about instructions used, etc.
-    - `cpuInsns`: `<string>` - Stringified-number of the total cpu instructions consumed by this transaction
-    - `memBytes`: `<string>` - Stringified-number of the total memory bytes allocated by this transaction
-  - `results`: `<object[]>` - If `error` is present then `results` will not be in the response. This array will only have one element: the result for the Host Function invocation.
-    - `xdr`: `<xdr.ScVal>` - (optional) Only present on success. xdr-encoded return value of the Host Function call.
-    - `auth`: `<xdr.ContractAuth[]>` - Per-address authorizations recorded when simulating this Host Function call. (an array of serialized base64 strings)
-  - `transactionData`: `<xdr.SorobanTransactionData>` - The recommended Soroban Transaction Data to use when submitting the simulated transaction. This data contains the refundable fee and resource usage information such as the ledger footprint and IO access data (serialized in a base64 string).
-  - `events`: `<xdr.DiagnosticEvent[]>` - Array of the events emitted during the contract invocation(s). The events are ordered by their emission _time_. (an array of serialized base64 strings)
-  - `latestLedger`: `<string>` - Stringified-number of the current latest ledger observed by the node when this response was generated.
-  - `error`: `<string>` - (optional) only present if the transaction failed. This field will include more details from `stellar-core` about why the invoke host function call failed.
+  - `minResourceFee`: `<string>` (optional) stringified number - Recommended minimum resource fee to add when submitting the transaction. This fee is to be added on top of the [Stellar network fee](https://developers.stellar.org/docs/encyclopedia/fees-surge-pricing-fee-strategies#network-fees-on-stellar). Not present in case of error.
+  - `cost`: `<object>` (optional) - Information about instructions used, etc. Not present in case of error.
+    - `cpuInsns`: `<string>` stringified number -  Total cpu instructions consumed by this transaction
+    - `memBytes`: `<string>` stringified number -  Total memory bytes allocated by this transaction
+  - `results`: `<object[]>` (optional) - This array will only have one element: the result for the Host Function invocation. Only present on successful simulation (i.e. no error) of `InvokeHostFunction` operations.
+    - `xdr`: `<xdr.ScVal>` serialized base64 string - return value of the Host Function call.
+    - `auth`: `<xdr.ContractAuth[]>` array of serialized base64 strings - Per-address authorizations recorded when simulating this Host Function call.
+  - `transactionData`: `<xdr.SorobanTransactionData>` (optional) serialized base64 string - The recommended Soroban Transaction Data to use when submitting the simulated transaction. This data contains the refundable fee and resource usage information such as the ledger footprint and IO access data (serialized in a base64 string). Not present in case of error.
+  - `events`: `<xdr.DiagnosticEvent[]>` (optional) array of serialized base64 strings - Array of the events emitted during the contract invocation. The events are ordered by their emission _time_. (an array of serialized base64 strings). Only present when simulating of `InvokeHostFunction` operations, note that it can be present on error, providing extra context about what failed.
+  - `restorePreamble`: `<object>` (optional) - It can only present on successful simulation (i.e. no error) of `InvokeHostFunction` operations. If present, it indicates the simulation detected expired ledger entries which requires restoring with the submission of a `RestoreFootprint` operation before submitting the `InvokeHostFunction` operation. The `minResourceFee` and `transactionData` fields should be used to construct the transaction containing the `RestoreFootprint` operation.
+    - `minResourceFee`: `<string>` stringified number -  Recommended minimum resource fee to add when submitting the `RestoreFootprint` operation. This fee is to be added on top of the [Stellar network fee](https://developers.stellar.org/docs/encyclopedia/fees-surge-pricing-fee-strategies#network-fees-on-stellar).
+    - `transactionData`: `<xdr.SorobanTransactionData>` serialized base64 string - The recommended Soroban Transaction Data to use when submitting the `RestoreFootprint` operation.
+  - `latestLedger`: `<string>` stringified number - Current latest closed ledger (LCL) observed by the node when this response was generated. Always present.
+  - `error`: `<string>` (optional) - This field will include details about why the invoke host function call failed. Only present if the transaction simulation failed.
 
 ## Examples
 
@@ -54,12 +57,6 @@ Submit a trial contract invocation to simulate how it would be executed by the n
       {
         "auth": [
           "AAAAAQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAAAAAAAOGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAABGF1dGgAAAACAAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAPAAAABXdvcmxkAAAAAAAAAAAAAAA="
-        ],
-        "xdr": "AAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8Bfc="
-      },
-      {
-        "auth": [
-          "AAAAAQAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAAAAAAAeGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAABGF1dGgAAAACAAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAPAAAABXdvcmxkAAAAAAAAAAAAAAA="
         ],
         "xdr": "AAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8Bfc="
       }


### PR DESCRIPTION
* Add new fields
* Move optionality explanations to the end
* Make the documention of every field consistent
* Remove multiple results from the example (since multiop transactions are not supported)