### PR TITLE
Corrects a 404 link to an old freighter URL

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -216,7 +216,7 @@ const GettingStarted = () => (
           index="4."
           title="Connect Freighter wallet"
           subtitle="Freighter is a browser extension that can sign Soroban transactions."
-          href="/docs/getting-started/connect-freighter-wallet"
+          href="/docs/reference/freighter"
         />
 
         <GettingStartedCard


### PR DESCRIPTION
In the past 30 days, the old URL has received nearly 100 clicks, and it's the only one that did get a 404 page on this docs site. This commit fixes the link on the index page. It's possible there are external links, that we can't control. If that's the case, we may want an nginx redirect. But, that's something we'll have to monitor and fix down the road.