### PR TITLE
Suggest Helm usage on RPC deployment

### DIFF
--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -156,22 +156,22 @@ This example of helm chart usage, highlights some key aspects:
 
     <CodeExample>
 
-    ```bash
-    --set sorobanRpc.persistence.enabled=true
-    --set sorobanRpc.persistence.storageClass=default
-    ```
+  ```bash
+  --set sorobanRpc.persistence.enabled=true
+  --set sorobanRpc.persistence.storageClass=default
+  ```
 
     </CodeExample>
 
-    By default `sorobanRpc.persistence.enabled=false` and the rpc deployment will use ephemeral pod storage via `emptyDir` which will likely be adequate for `futurenet` and `testnet` transaction volumes, but it's worth highlighting the trade-off, which is size limitations enforced from the cluster, most likely lower than 100MB.
+  By default `sorobanRpc.persistence.enabled=false` and the rpc deployment will use ephemeral pod storage via `emptyDir` which will likely be adequate for `futurenet` and `testnet` transaction volumes, but it's worth highlighting the trade-off, which is size limitations enforced from the cluster, most likely lower than 100MB.
 
 - Network presets are defined on [values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other 'canned' values.yaml files which have been published for other networks, for example, there is the [testnet-values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) to configure deployment of rpc server with `testnet` network. Include this `--values` parameter in `helm install` to specify the desired network:
 
     <CodeExample>
 
-    ```bash
-    --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/testnet-values.yaml
-    ```
+  ```bash
+  --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/testnet-values.yaml
+  ```
 
     </CodeExample>
 
@@ -179,20 +179,20 @@ This example of helm chart usage, highlights some key aspects:
 
     <CodeExample>
 
-    ```bash
-    --values my-custom-values.yaml
-    ```
+  ```bash
+  --values my-custom-values.yaml
+  ```
 
     </CodeExample>
 
-- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config, if defined, ensure that the defaults provide at least minimum rpc server resource limits of `3Gi` of memory and `1` cpu. Otherwise, include the limits explicitly on the helm install via the `sorobanRpc.resources.limits.*`.
+- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config, if defined, ensure that the defaults provide at least minimum rpc server resource limits of `2.5Gi` of memory and `1` cpu. Otherwise, include the limits explicitly on the helm install via the `sorobanRpc.resources.limits.*`.
 
     <CodeExample>
 
-    ```bash
-    --set sorobanRpc.resources.limits.cpu=1
-    --set sorobanRpc.resources.limits.memory=2560Mi
-    ```
+  ```bash
+  --set sorobanRpc.resources.limits.cpu=1
+  --set sorobanRpc.resources.limits.memory=2560Mi
+  ```
 
     </CodeExample>
 

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -120,47 +120,88 @@ These providers host an publicly available RPC endpoint that you can connect to.
 
 ## Deploy your own RPC instance
 
-If your target deployment environment includes Kubernetes infrastructure, you can utilize [soroban rpc helm chart](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc) for an automated deployment on the cluster. Install the [Helm cli tool](https://helm.sh/docs/intro/install/), minimum of version 3 if you haven't already on your workstation. Next, add the Stellar repo to the helm client's list of repos, update it to the latest published versions, and then install, including `--devel` enables using the latest development version published of the chart:
+If your target deployment environment includes Kubernetes infrastructure, you can utilize [soroban rpc helm chart](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc) for an automated deployment on the cluster. Install the [Helm cli tool](https://helm.sh/docs/intro/install/), minimum of version 3 if you haven't already on your workstation. Next, add the Stellar repo to the helm client's list of repos, update it to the latest published versions:
 
 <CodeExample>
 
 ```bash
 helm repo add stellar https://helm.stellar.org/charts
 helm repo update stellar
-helm install myrpc stellar/soroban-rpc \
-  --namespace my-rpc-namespace-on-cluster \
-  --set global.image.sorobanRpc.tag=0.9.2 \
-  --set sorobanRpc.ingress.host=myrpc.mydomain.com \
-  --devel
 ```
 
 </CodeExample>
 
-Set the `global.image.sorobanRpc.tag` to a tag from the [soroban rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [Soroban Releases](https://soroban.stellar.org/docs/reference/releases) to find the correct tag to use for the soroban release you are running.
-
-This example helm chart usage accepts all defaults currently defined on [values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) which defines network configuration specific to `futurenet`. If you want to use a different network config, you can download other network specific `values.yaml` which have been published, for example, there is the [testnet-values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) for configuring deployment on `testnet`.
-
-Or you can download the [values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) and update settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig` to align to the network you want. Then pass your local values.yaml to `helm install`:
+Deploy rpc to kubernetes using the helm chart:
 
 <CodeExample>
 
 ```bash
-helm install myrpc stellar/soroban-rpc \
+helm install my-rpc stellar/soroban-rpc \
 --namespace my-rpc-namespace-on-cluster \
--f values.yaml \
---devel
+--set global.image.sorobanRpc.tag=0.9.2 \
+--set sorobanRpc.ingress.host=rpc-futurenet-dev.stellar.org \
+--set sorobanRpc.persistence.enabled=true \
+--set sorobanRpc.persistence.storageClass=default \
+--set sorobanRpc.resources.limits.cpu=1 \
+--set sorobanRpc.resources.limits.memory=2560Mi
 ```
 
 </CodeExample>
+
+This example of helm chart usage, highlights some key aspects:
+
+- Set the `global.image.sorobanRpc.tag` to a tag from the [soroban rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [Soroban Releases](https://soroban.stellar.org/docs/reference/releases) to find the correct tag to use for the soroban release you are running.
+
+- The Rpc server stores a revolving window of recent data from network ledgers to disk. The sizing of that data will vary depending on the network and it's transaction volumes, estimated range between 10 to 100 MB. To ensure rpc pod has consistent access to disk storage space and r/w throughput, this example demonstrates how to optionally enable helm chart deployment to use a PersistentVolumeClaim(PVC) of 100MB from `default` storage class on kubernetes by enabling persistence parameters:
+
+    <CodeExample>
+
+    ```bash
+    --set sorobanRpc.persistence.enabled=true
+    --set sorobanRpc.persistence.storageClass=default
+    ```
+
+    </CodeExample>
+
+    By default `sorobanRpc.persistence.enabled=false` and the rpc deployment will use ephemeral pod storage via `emptyDir` which will likely be adequate for `futurenet` and `testnet` transaction volumes, but it's worth highlighting the trade-off, which is size limitations enforced from the cluster, most likely lower than 100MB.
+
+- Network presets are defined on [values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other 'canned' values.yaml files which have been published for other networks, for example, there is the [testnet-values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) to configure deployment of rpc server with `testnet` network. Include this `--values` parameter in `helm install` to specify the desired network:
+
+    <CodeExample>
+
+    ```bash
+    --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/testnet-values.yaml
+    ```
+
+    </CodeExample>
+
+- Configuring rpc to use other custom networks can be accomplished by downloading the [values.yaml](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) locally and updating settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig`. This is applicable for when needing to connect to specific networks other than the 'canned' values.yaml files available, such as your own standalone network. Include the local values.yaml in `helm install`:
+
+    <CodeExample>
+
+    ```bash
+    --values my-custom-values.yaml
+    ```
+
+    </CodeExample>
+
+- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config, if defined, ensure that the defaults provide at least minimum rpc server resource limits of `3Gi` of memory and `1` cpu. Otherwise, include the limits explicitly on the helm install via the `sorobanRpc.resources.limits.*`.
+
+    <CodeExample>
+
+    ```bash
+    --set sorobanRpc.resources.limits.cpu=1
+    --set sorobanRpc.resources.limits.memory=2560Mi
+    ```
+
+    </CodeExample>
 
 If kubernetes is not an option, the manifests generated by the charts may still be good reference for showing how to configure and run soroban rpc as docker container. Just run the helm command with `template` to print the container config to screen:
 
 <CodeExample>
 
 ```bash
-helm template myrpc stellar/soroban-rpc \
--f values.yaml \
---devel
+helm template my-rpc stellar/soroban-rpc
 ```
 
 </CodeExample>


### PR DESCRIPTION
Updated helm examples to show resource limits and removed `--devel` usage since charts will be released now.