### PR TITLE
Changing the "Getting Started" section cards

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -207,23 +207,22 @@ const GettingStarted = () => (
 
         <GettingStartedCard
           index="3."
-          title="Deploy to a local network"
-          subtitle="Use docker and the Stellar Quickstart image to run a local network."
-          href="/docs/getting-started/deploy-to-a-local-network"
+          title="Deploy to Futurenet"
+          subtitle="Deploy and invoke your contracts on the Futurenet testnet."
+          href="/docs/getting-started/deploy-to-futurenet"
         />
 
         <GettingStartedCard
           index="4."
-          title="Connect Freighter wallet"
-          subtitle="Freighter is a browser extension that can sign Soroban transactions."
-          href="/docs/reference/freighter"
+          title="Create an App"
+          subtitle="Build a front-end app to interact with your Soroban contracts."
+          href="/docs/getting-started/deploy-to-futurenet"
         />
 
         <GettingStartedCard
-          index="5."
-          title="Deploy to Futurenet"
-          subtitle="Deploy and invoke your contracts on the Futurenet testnet."
-          href="/docs/getting-started/deploy-to-futurenet"
+          title="Deploy to a local network"
+          subtitle="Use docker and the Stellar Quickstart image to run a local network."
+          href="/docs/reference/rpc#standalone"
         />
       </div>
     </div>


### PR DESCRIPTION
This commit does a couple things:

1. Fixes an old link for the "deploy to a local network" card that was moved some time ago. We were receiving a few 404 errors for that old URL.
2. Changes the cards to be more in-line with the current structure of the "Getting Started" section of docs on our site.

I've removed the link to "freighter wallet" since freighter is covered in the "create an app" page, although I'm not entirely sure if that or "deploy to a local network" is more useful to have here. Would love some thoughts from others.