### PR TITLE
docs: Corrects a parameter misspelling in the token interface

### DIFF
--- a/docs/reference/interfaces/token-interface.mdx
+++ b/docs/reference/interfaces/token-interface.mdx
@@ -74,7 +74,7 @@ pub trait Contract {
     fn set_authorized(
         env: soroban_sdk::Env,
         id: Address,
-        authorized: bool,
+        authorize: bool,
     );
 
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
The token interface has the `set_authorized` function, that is intended to take the parameters

- `id`: the address to be (un)authorized
- `authorize`: boolean value for if the address should(n't) be authorized

Our docs list that second parameter as `authorized`, with a `d` at the end. This is incorrect and causes confusion/errors.