### PR TITLE
feat: Display example RPC requests as a useable CURL command

### DIFF
--- a/api/methods/getEvents.mdx
+++ b/api/methods/getEvents.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 2
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 Clients can request a filtered list of events emitted by a given ledger range.
 
 Soroban-RPC will support querying within a maximum 24 hours of recent ledgers.
@@ -66,30 +68,23 @@ The examples below only returns two transfer events that took place to/from the 
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 8675309,
-  "method": "getEvents",
-  "params": {
-    "startLedger": "227000",
-    "filters": [
-      {
-        "type": "contract",
-        "contractIds": [
-          "d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813"
-        ],
-        "topics": [
-          ["AAAABQAAAAh0cmFuc2Zlcg==", "*", "*"]
-        ]
-      }
-    ],
-    "pagination": {
-      "limit": 100
+<ExampleRequest method="getEvents" params={{
+  startLedger: "227000",
+  filters: [
+    {
+      type: "contract",
+      contractIds: [
+        "CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT"
+      ],
+      topics: [
+        ["AAAABQAAAAh0cmFuc2Zlcg==", "*", "*"]
+      ]
     }
+  ],
+  pagination: {
+    limit: 100
   }
-}
-```
+}} />
 
 ### Response
 

--- a/api/methods/getHealth.mdx
+++ b/api/methods/getHealth.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 3
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 General node health check.
 
 ## Parameters
@@ -17,13 +19,7 @@ General node health check.
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 8675309,
-  "method": "getHealth"
-}
-```
+<ExampleRequest method="getHealth" />
 
 ### Response
 

--- a/api/methods/getLatestLedger.mdx
+++ b/api/methods/getLatestLedger.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 For finding out the current latest known ledger of this node. This is a subset of the ledger info from Horizon.
 
 ## Parameters
@@ -19,13 +21,7 @@ For finding out the current latest known ledger of this node. This is a subset o
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 8675309,
-  "method": "getLatestLedger"
-}
-```
+<ExampleRequest method="getLatestLedger" />
 
 ### Response
 

--- a/api/methods/getLedgerEntries.mdx
+++ b/api/methods/getLedgerEntries.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 4
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 For reading the current value of ledger entries directly.
 
 Allows you to directly inspect the _current state_ of a contract, a contract's code, or any other ledger entry. This is a backup way to access your contract data which may not be available via events or `simulateTransaction`.
@@ -25,16 +27,7 @@ To fetch contract wasm byte-code, use the ContractCode ledger entry key.
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 8675309,
-  "method": "getLedgerEntries",
-  "params": {
-    "keys": ["AAAAB+qfy4GuVKKfazvyk4R9P9fpo2n9HICsr+xqvVcTF+DC","AAAABuGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAAFA=="]
-  }
-}
-```
+<ExampleRequest method="getLedgerEntries" params={{keys: ["AAAAB+qfy4GuVKKfazvyk4R9P9fpo2n9HICsr+xqvVcTF+DC","AAAABuGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAAFA=="]}} />
 
 ### Response
 

--- a/api/methods/getNetwork.mdx
+++ b/api/methods/getNetwork.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 5
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 General info about the currently configured network.
 
 ## Parameters
@@ -14,3 +16,23 @@ General info about the currently configured network.
   - `friendbotUrl`: `<string>` (optional) - The URL of this network's "friendbot" faucet
   - `passphrase`: `<string>` - Network passphrase configured
   - `protocolVersion`: `<string>` - Protocol version of the latest ledger
+
+## Examples
+
+### Request
+
+<ExampleRequest method="getNetwork" />
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8675309,
+  "result": {
+    "friendbotUrl": "https://friendbot-futurenet.stellar.org/",
+    "passphrase": "Test SDF Future Network ; October 2022",
+    "protocolVersion": "20"
+  }
+}
+```

--- a/api/methods/getTransaction.mdx
+++ b/api/methods/getTransaction.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 8
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 Clients will poll this to tell when the transaction has been completed.
 
 
@@ -32,16 +34,7 @@ Clients will poll this to tell when the transaction has been completed.
 
 ### Request
 
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 8675309,
-    "method": "getTransactionStatus",
-    "params": {
-        "hash": "a01441a4d0b80769d2c2d97dcd28d13e9036065da14ea83731424d77efc50894"
-    }
-}
-```
+<ExampleRequest method="getTransaction" params={{hash: "a01441a4d0b80769d2c2d97dcd28d13e9036065da14ea83731424d77efc50894"}} />
 
 ### Response
 

--- a/api/methods/sendTransaction.mdx
+++ b/api/methods/sendTransaction.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 7
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 Submit a real transaction to the Stellar network. This is the only way to make changes "on-chain".
 
 Unlike Horizon, this does not wait for transaction completion. It simply validates and enqueues the transaction. Clients should call getTransaction to learn about transaction success/failure.
@@ -29,16 +31,7 @@ This supports all transactions, not only smart contract-related transactions.
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 8675309,
-  "method": "sendTransaction",
-  "params": {
-    "transaction": "AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAp18AAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAHN2/eiOTNYcwPspSheGs/HQYfXy8cpXRl+qkyIRuUbWAAAAGAAAAAEAAAABAAAAAPVf8W9m9DNgJmuV22+P7AHXYDEFQwauSks4BZj2z9EUAAAAAO3beL34UBBpCfUUPCfcnqX8YQKn41UhnKu6BInkVe9lAAAAAAAAAAEAAAABAAAAB+3beL34UBBpCfUUPCfcnqX8YQKn41UhnKu6BInkVe9lAAAAAQAAAAbhq+vRxjISTR62JpK1SAnzz1cZKpSpkRlwLJH6ZrzssgAAABQAAUKLAAAUkAAAAIAAAACoAAAAAAAAACEAAAAAAAAAARG5RtYAAABA+Vy3k86bNEP7rP8hb3cY1QWYhRa3CnF7jqHUj22Rd++2a0YwCKrMbofTUOb21GP6aFZwfKVvaokS22u1to5xDw=="
-  }
-}
-```
+<ExampleRequest method="sendTransaction" params={{transaction: "AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAp18AAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAHN2/eiOTNYcwPspSheGs/HQYfXy8cpXRl+qkyIRuUbWAAAAGAAAAAEAAAABAAAAAPVf8W9m9DNgJmuV22+P7AHXYDEFQwauSks4BZj2z9EUAAAAAO3beL34UBBpCfUUPCfcnqX8YQKn41UhnKu6BInkVe9lAAAAAAAAAAEAAAABAAAAB+3beL34UBBpCfUUPCfcnqX8YQKn41UhnKu6BInkVe9lAAAAAQAAAAbhq+vRxjISTR62JpK1SAnzz1cZKpSpkRlwLJH6ZrzssgAAABQAAUKLAAAUkAAAAIAAAACoAAAAAAAAACEAAAAAAAAAARG5RtYAAABA+Vy3k86bNEP7rP8hb3cY1QWYhRa3CnF7jqHUj22Rd++2a0YwCKrMbofTUOb21GP6aFZwfKVvaokS22u1to5xDw=="}} />
 
 ### Response
 

--- a/api/methods/simulateTransaction.mdx
+++ b/api/methods/simulateTransaction.mdx
@@ -2,7 +2,10 @@
 sidebar_position: 8
 ---
 
+import ExampleRequest from "@site/src/components/ExampleRequest";
+
 Submit a trial contract invocation to simulate how it would be executed by the network. This endpoint calculates the effective transaction data, required authorizations, and minimal resource fee. It provides a way to test and analyze the potential outcomes of a transaction without actually submitting it to the network.
+
 ## Parameters
 
 - `<xdr.TransactionEnvelope>` - The transaction to be simulated (serialized in base64)
@@ -29,16 +32,7 @@ Submit a trial contract invocation to simulate how it would be executed by the n
 
 ### Request
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1102,
-  "method": "simulateTransaction",
-  "params": {
-    "transaction": "AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAABAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAHN2/eiOTNYcwPspSheGs/HQYfXy8cpXRl+qkyIRuUbWAAAAGAAAAAIAAAAAAAAABAAAAA0AAAAg4avr0cYyEk0etiaStUgJ889XGSqUqZEZcCyR+ma87LIAAAAPAAAABGF1dGgAAAATAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAAAAAAQAAAANAAAAIOGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAADwAAAARhdXRoAAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAPAAAABXdvcmxkAAAAAAAAAAAAAAAAAAAA"
-  }
-}
-```
+<ExampleRequest method="simulateTransaction" params={{transaction: "AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAABAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAHN2/eiOTNYcwPspSheGs/HQYfXy8cpXRl+qkyIRuUbWAAAAGAAAAAIAAAAAAAAABAAAAA0AAAAg4avr0cYyEk0etiaStUgJ889XGSqUqZEZcCyR+ma87LIAAAAPAAAABGF1dGgAAAATAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAAAA8AAAAFd29ybGQAAAAAAAAAAAAAAAAAAAQAAAANAAAAIOGr69HGMhJNHrYmkrVICfPPVxkqlKmRGXAskfpmvOyyAAAADwAAAARhdXRoAAAAEwAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcAAAAPAAAABXdvcmxkAAAAAAAAAAAAAAAAAAAA"}} />
 
 ### Response
 

--- a/src/components/ExampleRequest/index.js
+++ b/src/components/ExampleRequest/index.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+import CodeBlock from "@theme/CodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+export default function ExampleRequest(props) {
+  let requestObject = {
+    jsonrpc: "2.0",
+    id: 8675309,
+    method: props.method,
+  }
+
+  if (props.params) {
+    requestObject.params = { ...props.params }
+  }
+
+  return (
+    <Tabs
+      defaultValue={"curl"}
+      values={[
+        { label: "Curl", value: "curl" },
+        { label: "JavaScript", value: "js" },
+        { label: "Python", value: "py" },
+        { label: "JSON", value: "json"},
+      ]}
+    >
+      <TabItem value="curl">
+        <CodeBlock language="bash">
+{`curl -X POST \\
+-H 'Content-Type: application/json' \\
+-d '${JSON.stringify(requestObject, null, 2)}' \\
+https://rpc-futurenet.stellar.org | jq`}
+        </CodeBlock>
+      </TabItem>
+
+      <TabItem value="js">
+        <CodeBlock language="js">
+{`let requestObject = ${JSON.stringify(requestObject, null, 2)}
+let res = await fetch('https://rpc-futurenet.stellar.org', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(requestObject),
+)
+let json = await res.json()
+console.log(json)`}
+        </CodeBlock>
+      </TabItem>
+
+      <TabItem value="py">
+        <CodeBlock language="python">
+{`import json, requests
+res = requests.post('https://rpc-futurenet.stellar.org', json=${JSON.stringify(requestObject, null, 4)})
+print(json.dumps(res.json(), indent=2))`}
+        </CodeBlock>
+      </TabItem>
+
+      <TabItem value="json">
+        <CodeBlock language="json">
+{JSON.stringify(requestObject, null, 2)}
+        </CodeBlock>
+      </TabItem>
+    </Tabs>
+  )
+}


### PR DESCRIPTION
Also displaying generic code snippets for popular languages, as well as in raw JSON format.

A new `ExampleRequest` component has been made to facilitate this, as well. This component takes a `method` prop for the name of the RPC method being called, as well as an optional `params` prop which can pass the object that should be used to populate the RPC request object.

Refs: #565