### PR TITLE
Update soroban versions to 20.0.0-rc2

### DIFF
--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -285,7 +285,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "0.9.1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -285,7 +285,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/docs/basic-tutorials/alloc.mdx
+++ b/docs/basic-tutorials/alloc.mdx
@@ -62,10 +62,10 @@ This example depends on the `alloc` feature in `soroban-sdk`. To include it, add
 
 ```rust title="alloc/Cargo.toml"
 [dependencies]
-soroban-sdk = { version = "0.9.2", features = ["alloc"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["alloc"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.9.2", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils", "alloc"] }
 ```
 
 ## Code

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -255,11 +255,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "20.0.0-rc1" }
+soroban-sdk = { version = "20.0.0-rc2" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -255,11 +255,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "0.9.2" }
+soroban-sdk = { version = "20.0.0-rc1" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.9.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -575,10 +575,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc1"
+soroban-sdk = "20.0.0-rc2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -575,10 +575,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.9.2"
+soroban-sdk = "20.0.0-rc1"
 
 [dev_dependencies]
-soroban-sdk = { version = "0.9.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -64,10 +64,10 @@ The `soroban-sdk` is in early development. Report issues [here](https://github.c
 
 ```toml
 [dependencies]
-soroban-sdk = "20.0.0-rc1"
+soroban-sdk = "20.0.0-rc2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
@@ -132,10 +132,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc1"
+soroban-sdk = "20.0.0-rc2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"
@@ -373,7 +373,7 @@ and
 
 Use `soroban contract optimize` to further minimize the size of the `.wasm`. First, re-install soroban-cli with the `opt` feature:
 
-    cargo install --locked --version 20.0.0-rc1 soroban-cli --features opt
+    cargo install --locked --version 20.0.0-rc2 soroban-cli --features opt
 
 Then build an optimized `.wasm` file:
 

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -64,10 +64,10 @@ The `soroban-sdk` is in early development. Report issues [here](https://github.c
 
 ```toml
 [dependencies]
-soroban-sdk = "0.9.2"
+soroban-sdk = "20.0.0-rc1"
 
 [dev_dependencies]
-soroban-sdk = { version = "0.9.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
@@ -132,10 +132,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.9.2"
+soroban-sdk = "20.0.0-rc1"
 
 [dev_dependencies]
-soroban-sdk = { version = "0.9.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"
@@ -373,7 +373,7 @@ and
 
 Use `soroban contract optimize` to further minimize the size of the `.wasm`. First, re-install soroban-cli with the `opt` feature:
 
-    cargo install --locked --version 0.9.1 soroban-cli --features opt
+    cargo install --locked --version 20.0.0-rc1 soroban-cli --features opt
 
 Then build an optimized `.wasm` file:
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -74,7 +74,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```bash
-cargo install --locked --version 0.9.4 soroban-cli
+cargo install --locked --version 20.0.0-rc1 soroban-cli
 ```
 
 :::info

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -74,7 +74,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```bash
-cargo install --locked --version 20.0.0-rc1 soroban-cli
+cargo install --locked --version 20.0.0-rc2 soroban-cli
 ```
 
 :::info


### PR DESCRIPTION
This PR upgrades all existing references to use Soroban 20.0.0-rc2, replacing earlier versions.




