### PR TITLE
bump quickstart sha ref to latest for preview11

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -27,11 +27,11 @@ Preview releases are software releases that are also released to the [Testnet] t
 | Soroban Interface Version    | `57`                                                                                                                               |
 | Stellar Core                 | `20.0.0-1504.rc2.22088c1f2.focal`                                                                                                  |
 | Soroban Rust SDK             | `v20.0.0-rc2`                                                                                                                      |
-| Soroban CLI                  | `v20.0.0-rc2`                                                                                                                      |
-| Soroban RPC                  | `v20.0.0-rc3`                                                                                                                      |
+| Soroban CLI                  | `v20.0.0-rc4`                                                                                                                      |
+| Soroban RPC                  | `v20.0.0-rc4`                                                                                                                      |
 | Stellar Horizon              | `2.27.0~rc2-384`                                                                                                                   |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                             |
-| Stellar Quickstart           | `stellar/quickstart:testing@sha256:1c98f895f8b69cc843eeaa5230d67044dbeb390a5529d51dd7762d8ff685c3f8`                               |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:40636cdb1b9168b47e5dc120949fe3610ff914e8dd43409edb6fa66496bdd9c3`                               |
 | Stellar JS Stellar Base      | `10.0.0-beta.1`                                                                                                                    |
 | Stellar JS Soroban Client    | `v1.0.0-beta.2`                                                                                                                    |
 | Freighter                    | `5.6.1`                                                                                                                            |

--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -31,7 +31,7 @@ Preview releases are software releases that are also released to the [Testnet] t
 | Soroban RPC                  | `v20.0.0-rc4`                                                                                                                      |
 | Stellar Horizon              | `2.27.0~rc2-384`                                                                                                                   |
 | Stellar Friendbot            | `soroban-v0.0.2-alpha`                                                                                                             |
-| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:40636cdb1b9168b47e5dc120949fe3610ff914e8dd43409edb6fa66496bdd9c3`                               |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:40636cdb1b9168b47e5dc120949fe3610ff914e8dd43409edb6fa66496bdd9c3`                     |
 | Stellar JS Stellar Base      | `10.0.0-beta.1`                                                                                                                    |
 | Stellar JS Soroban Client    | `v1.0.0-beta.2`                                                                                                                    |
 | Freighter                    | `5.6.1`                                                                                                                            |


### PR DESCRIPTION
updated the quickstart image sha ref for latest build with rc4 versions on preview 11 release docs.