### PR TITLE
docs: explain the diagnostic events that are emitted in sandbox

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -376,11 +376,11 @@ soroban contract invoke ... -- hello --help
 
 ### Diagnostic Events
 
-You will also notice here (and with any other contract run in the sandbox environment) some diagnostic output will be displayed on the screen. This is because `soroban-cli` automatically sets the diagnostic level to "Debug" for contracts running in the sandbox.
+You will also notice here (and with any other contract run in the sandbox environment) that some diagnostic output will be displayed on the screen. This is because the `soroban-cli` automatically sets the diagnostic level to "Debug" for contracts running in the sandbox.
 
 Here, we'll see two diagnostic events were emitted by our contract invocation:
 
-1. First is a `fn_call` diagnostic event. It tells you the _kind_ of event, the contract ID which will be called, the name of the function being called, and a vector of the arguments passed to the function. A (greatly simplified) version of this event's body would look like this:
+1. First is a `fn_call` diagnostic event. It tells you the _kind_ of event, the contract ID that will be called, the name of the function being called, and a vector of the arguments passed to the function. A (greatly simplified) version of this event's body would look like this:
 
 ```
 {

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -352,22 +352,71 @@ soroban contract invoke \
     --to friend
 ```
 
-The following output should appear.
+The contract invocation should result in the following output.
 
 ```json
 ["Hello", "friend"]
 ```
 
 :::info The `--` double-dash is required!
+
 This is a general [CLI pattern](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean) used by other commands like [cargo run](https://doc.rust-lang.org/cargo/commands/cargo-run.html). Everything after the `--`, sometimes called [slop](https://github.com/clap-rs/clap/issues/971), is passed to a child process. In this case, `soroban contract invoke` builds an _implicit CLI_ on-the-fly for the `hello` method in your contract. It can do this because Soroban SDK embeds your contract's schema / interface types right in the `.wasm` file that gets deployed on-chain. You can also try:
 
-    soroban contract invoke ... -- --help
+```bash
+soroban contract invoke ... -- --help
+```
 
 and
 
-    soroban contract invoke ... -- hello --help
+```bash
+soroban contract invoke ... -- hello --help
+```
 
 :::
+
+### Diagnostic Events
+
+You will also notice here (and with any other contract run in the sandbox environment) some diagnostic output will be displayed on the screen. This is because `soroban-cli` automatically sets the diagnosticlevel to "Debug" for contracts running in the sandbox.
+
+Here, we'll see two diagnostic events were emitted by our contract invocation:
+
+1. First is a `fn_call` diagnostic event. It tells you the _kind_ of event, the contract ID which will be called, the name of the function being called, and a vector of the arguments passed to the function. A (greatly simplified) version of this event's body would look like this:
+
+```
+{
+    event: {
+        body: {
+            topics: [
+                Symbol(fn_call),
+                Bytes(0000000000000000000000000000000000000000000000000000000000000001),
+                Symbol(hello),
+            ],
+            data: Symbol(friend),
+        }
+    }
+}
+```
+
+2. Next is a `fn_return` diagnostic event. These events are emitted when a contract call completes and contains the _kind_ of event, the name of the function that is returning, and the value returned by the function. A (greatly simplified) version of this event's body would look like this:
+
+```
+{
+    event: {
+        body: {
+            topics: [
+                Symbol(fn_return),
+                Symbol(hello),
+            ],
+            data: [
+                Symbol(Hello),
+                Symbol(friend),
+            ]
+        }
+    }
+}
+```
+
+You can learn more about diagnostic events in our [Events article](../fundamentals-and-concepts/events#what-are-diagnosticevents).
 
 ## Optimizing Builds
 

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -376,7 +376,7 @@ soroban contract invoke ... -- hello --help
 
 ### Diagnostic Events
 
-You will also notice here (and with any other contract run in the sandbox environment) some diagnostic output will be displayed on the screen. This is because `soroban-cli` automatically sets the diagnosticlevel to "Debug" for contracts running in the sandbox.
+You will also notice here (and with any other contract run in the sandbox environment) some diagnostic output will be displayed on the screen. This is because `soroban-cli` automatically sets the diagnostic level to "Debug" for contracts running in the sandbox.
 
 Here, we'll see two diagnostic events were emitted by our contract invocation:
 


### PR DESCRIPTION
Perhaps this approach is too verbose? I think having the explanation of what is being seen right there in the tutorial is useful at this early step in the "getting started" section. A new developer is more likely to understand what they see, and remember what it is in the future if we don't try to interrupt their flow at this point by sending them to another page for some (possibly irrelevant) info.

I may be incorrect there, and I'm happy to hear opinions from others.

Resolves #521