### PR TITLE
RPC `getEvents`: clarify that IDs are StrKeys

### DIFF
--- a/api/methods/getEvents.mdx
+++ b/api/methods/getEvents.mdx
@@ -26,7 +26,7 @@ By default soroban-rpc retains the most recent 24 hours of events.
     - A `SegmentMatcher` is one of the following:
       - For an exact segment match, a string containing base64-encoded ScVal
       - For a wildcard single-segment match, the string "*", matches exactly one segment.
-    - Examples of matching token transfer events. Events are emitted here: [rs-soroban-env/event.rs at 924d86cacd58b8a162344bfe0ab37d9668f5d629]. I've decoded the base64-encoded ScVals for easier reading (both the symbols and addresses). In real usage, the `ScSymbol("transfer").toXdr().toString("base64")`, and `ScBinary(pubkeyBytes).toXdr().toString("base64")`, would be base64 encoded strings for exact matches. For example:
+    - Examples of matching token transfer events. Events are emitted here: [rs-soroban-env/event.rs @ `924d86c`], with base64-encoded ScVals decoded for easier reading (both the symbols and addresses). In real usage, the `ScSymbol("transfer").toXdr().toString("base64")`, and `ScBinary(pubkeyBytes).toXdr().toString("base64")`, would be base64-encoded strings for exact matches. For example:
       - `[ScSymbol("transfer"), "*", "*"]`
         - Matches any token transfer events
       - `[ScSymbol("transfer"), "*", "GABC...123"]`
@@ -41,15 +41,14 @@ By default soroban-rpc retains the most recent 24 hours of events.
   - `latestLedger`: `<string>` - Stringified-number of the current latest ledger observed by the node when this response was generated.
   - `events`: `<object[]>`
     - `ledger`: `<string>` - String-ified sequence number of the ledger.
-    - `ledgerClosedAt`: `<string>` - ISO8601 timestamp of the ledger closing time.
-    - `contractId`: `<string>` - ID of the emitting contract.
+    - `ledgerClosedAt`: `<string>` - [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of the ledger closing time.
+    - `contractId`: `<string>` - StrKey ID (`C...`) of the emitting contract ([SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md#specification)).
     - `id`: `<string>` - Unique identifier for this event.
       - The event's unique id field is based on a [`toid` from Horizon] as used in Horizon's /effects endpoint.
       - https://github.com/stellar/go/blob/master/services/horizon/internal/db2/history/effect.go#L58
       - Specifically, it is a string containing:
-      - bigint(32 bit ledger sequence + 20 bit txn number + 12 bit operation) + `<hyphen>` + number for the event within the operation.
-      - For example:
-        - 1234-1
+        - bigint(32 bit ledger sequence + 20 bit txn number + 12 bit operation) + `<hyphen>` + number for the event within the operation.
+        - For example: `1234-1`
     - `pagingToken`: `<string>` - Duplicate of `id` field, but in the standard place for pagination tokens.
     - `inSuccessfulContractCall`: `<boolean>` - If true the event was emitted during a successful contract call.
     - `topic`: `<xdr.ScVal[]>` - List containing the topic this event was emitted with.
@@ -99,7 +98,7 @@ The examples below only returns two transfer events that took place to/from the 
         "type": "contract",
         "ledger": "230010",
         "ledgerClosedAt": "2023-01-23T18:54:41Z",
-        "contractId": "d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813",
+        "contractId": "CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT",
         "id": "0000987885427757056-0000000001",
         "pagingToken": "0000987885427757056-0000000001",
         "inSuccessfulContractCall": true,
@@ -116,7 +115,7 @@ The examples below only returns two transfer events that took place to/from the 
         "type": "contract",
         "ledger": "230170",
         "ledgerClosedAt": "2023-01-23T19:08:37Z",
-        "contractId": "d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813",
+        "contractId": "CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT",
         "id": "0000988572622524416-0000000001",
         "pagingToken": "0000988572622524416-0000000001",
         "inSuccessfulContractCall": true,
@@ -134,5 +133,5 @@ The examples below only returns two transfer events that took place to/from the 
 }
 ```
 
-[rs-soroban-env/event.rs at 924d86cacd58b8a162344bfe0ab37d9668f5d629]: <https://github.com/stellar/rs-soroban-env/blob/924d86cacd58b8a162344bfe0ab37d9668f5d629/soroban-env-host/src/native_contract/token/event.rs#L21-L33>
+[rs-soroban-env/event.rs @ `924d86c`]: <https://github.com/stellar/rs-soroban-env/blob/924d86cacd58b8a162344bfe0ab37d9668f5d629/soroban-env-host/src/native_contract/token/event.rs#L21-L33>
 [`toid` from Horizon]: <https://github.com/stellar/go/blob/master/toid/main.go>


### PR DESCRIPTION
I also cleaned up a link, changed language tense to avoid first-person, and added some cross-references.

Closes https://github.com/stellar/soroban-tools/issues/1007.