### PR TITLE
Corrected calculation of max pages.

### DIFF
--- a/src/components/molecules/leaderboard/index.tsx
+++ b/src/components/molecules/leaderboard/index.tsx
@@ -25,7 +25,7 @@ const Leaderboard: React.FC<Props> = ({ userId, list, isLoading, onLoad }) => {
   const [pageNumber, setPageNumber] = useState(1);
 
   const maxUsers = list[0]?.ranking.total;
-  const maxPage = maxUsers / PAGE_SIZE;
+  const maxPage = Math.ceil(maxUsers / PAGE_SIZE);
 
   const onSort = (val: LeaderboardColumn) => {
     // if click on current column ? change direction : set default direction


### PR DESCRIPTION
Right now, calculation of maxPage works incorrectly.
Let's assume leaderboard list contains 5 records.
pageNumber is equal to 1
PAGE_SIZE is equal to 10.

```
const maxPage = maxUsers / PAGE_SIZE;
```
maxPage = 5 / 10 = 0.5
Controls are disabled if `pageNumber === maxPage`. Since pageNumber == 1 and maxPage == 0.5, 'Next' and 'Prev' buttons aren't disabled as values aren't equal.

Implemented fix to round up maxPage to the next integer