### PR TITLE
Documentation Mismatch for Logging after SorobanSDK Update #615

### DIFF
--- a/docs/basic-tutorials/errors.mdx
+++ b/docs/basic-tutorials/errors.mdx
@@ -230,7 +230,7 @@ fn test() {
     assert_eq!(client.try_increment(), Ok(Ok(5)));
     assert_eq!(client.try_increment(), Err(Ok(Error::LimitReached)));
 
-    std::println!("{}", env.logger().all().join("\n"));
+    std::println!("{}", env.logs().all().join("\n"));
 }
 
 #[test]

--- a/docs/basic-tutorials/logging.mdx
+++ b/docs/basic-tutorials/logging.mdx
@@ -180,7 +180,7 @@ fn test() {
 
     client.hello(&symbol_short!("Dev"));
 
-    let logs = env.logger().all();
+    let logs = env.logs().all();
     assert_eq!(logs, std::vec!["Hello Symbol(Dev)"]);
     std::println!("{}", logs.join("\n"));
 }
@@ -222,7 +222,7 @@ let words = client.hello(&symbol_short!("Dev"));
 Logs are available in tests via the environment.
 
 ```rust
-let logs = env.logger().all();
+let logs = env.logs().all();
 ```
 
 They can asserted on like any other value.


### PR DESCRIPTION
This pull request fixes the problem mentioned in the #615 issue. Where it changes the work `logger` with `logs`.