### PR TITLE
fix "Create an App" link on the index page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -215,7 +215,7 @@ const GettingStarted = () => (
           index="4."
           title="Create an App"
           subtitle="Build a front-end app to interact with your Soroban contracts."
-          href="/docs/getting-started/deploy-to-testnet"
+          href="/docs/getting-started/create-an-app"
         />
 
         <GettingStartedCard


### PR DESCRIPTION
Currently, it directs to the "deploy to testnet" page