### PR TITLE
update getTransaction documentation

### DIFF
--- a/static/rpc-methods/getTransaction.json
+++ b/static/rpc-methods/getTransaction.json
@@ -1,6 +1,6 @@
 {
   "name": "getTransaction",
-  "description": "Clients will poll this to tell when the transaction has been completed.",
+  "description": "The getTransaction method provides details about the specified transaction, and clients are expected to periodically query this method to ascertain when a transaction has been successfully recorded on the blockchain. The soroban-rpc system maintains a restricted history of recently processed transactions, with the default retention window set at 1440 ledgers, approximately equivalent to a 2-hour timeframe. For private soroban-rpc instances, it is possible to modify the retention window value by adjusting the transaction-retention-window configuration setting.",
   "paramStructure": "by-name",
   "params": [
     {

--- a/static/rpc-methods/getTransaction.json
+++ b/static/rpc-methods/getTransaction.json
@@ -1,6 +1,6 @@
 {
   "name": "getTransaction",
-  "description": "The getTransaction method provides details about the specified transaction, and clients are expected to periodically query this method to ascertain when a transaction has been successfully recorded on the blockchain. The soroban-rpc system maintains a restricted history of recently processed transactions, with the default retention window set at 1440 ledgers, approximately equivalent to a 2-hour timeframe. For private soroban-rpc instances, it is possible to modify the retention window value by adjusting the transaction-retention-window configuration setting.",
+  "description": "The getTransaction method provides details about the specified transaction, and clients are expected to periodically query this method to ascertain when a transaction has been successfully recorded on the blockchain. The soroban-rpc system maintains a restricted history of recently processed transactions, with the default retention window set at 1440 ledgers, approximately equivalent to a 2-hour timeframe. For private soroban-rpc instances, it is possible to modify the retention window value by adjusting the transaction-retention-window configuration setting. For comprehensive debugging needs that extend beyond the 2-hour timeframe, it is advisable to retrieve transaction information from Horizon, as it provides a lasting and persistent record.",
   "paramStructure": "by-name",
   "params": [
     {


### PR DESCRIPTION
update getTransaction docs to:

The getTransaction method provides details about the specified transaction, and clients are required to periodically query this method to ascertain when a transaction has been successfully recorded on the blockchain. The soroban-rpc system maintains a restricted history of recently processed transactions, with the default retention window set at 1440 ledgers, approximately equivalent to a 2-hour timeframe. For private soroban-rpc instances, it is possible to modify the retention window value by adjusting the transaction-retention-window configuration setting.