### PR TITLE
Add RPC Deployment Details to RPC Usage Page

### DIFF
--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -232,7 +232,7 @@ By default, this is disabled (`sorobanRpc.persistence.enabled=false`) and the RP
 --values my-custom-values.yaml
 ```
 
-- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config. If defined, ensure that the defaults provide at least minimum RPC server resource limits of `2.5Gi` of memory and `1` CPU. Otherwise, include the limits explicitly on the `helm install` command via the `sorobanRpc.resources.limits.*` parameters:
+- Verify the `LimitRange` defaults in the target namespace in Kubernetes for deployment. `LimitRange` is optional on the cluster config. If defined, ensure that the defaults provide at least minimum RPC server resource limits of `2.5Gi` of memory and `1` CPU. Otherwise, include the limits explicitly on the `helm install` command via the `sorobanRpc.resources.limits.*` parameters:
 
 ```bash
 --set sorobanRpc.resources.limits.cpu=1

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -205,7 +205,7 @@ helm repo update stellar
 ```bash
 helm install my-rpc stellar/soroban-rpc \
 --namespace my-rpc-namespace-on-cluster \
---set global.image.sorobanRpc.tag=20.0.0-rc3-39 \
+--set global.image.sorobanRpc.tag=20.0.0-rc4-40 \
 --set sorobanRpc.ingress.host=myrpc.example.org \
 --set sorobanRpc.persistence.enabled=true \
 --set sorobanRpc.persistence.storageClass=default \
@@ -266,7 +266,7 @@ Here's how to run the [soroban-rpc docker image](https://hub.docker.com/r/stella
 1. Pull the image at the version you'd like to run from [the tags](https://hub.docker.com/r/stellar/soroban-rpc/tags):
 
 ```bash
-docker pull stellar/soroban-rpc:20.0.0-rc3-39
+docker pull stellar/soroban-rpc:20.0.0-rc4-40
 ```
 
 2. Create a configuration file for [Stellar Core](https://github.com/stellar/stellar-core). Here is a sample configuration file for Testnet:
@@ -310,7 +310,7 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{
 
 ```bash
 docker run -p 8001:8001 -p 8000:8000 \
--v <STELLAR_CORE_CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc3-39 \
+-v <STELLAR_CORE_CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc4-40 \
 --captive-core-config-path="/config/<STELLAR_CORE_CONFIG_PATH>" \
 --captive-core-storage-path="/var/lib/stellar/captive-core" \
 --captive-core-use-db=true \
@@ -330,14 +330,14 @@ For production, we recommend running Soroban RPC with a [TOML](https://toml.io/e
 
 ```bash
 docker run -p 8001:8001 -p 8000:8000 \
--v <CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc3-39 \
+-v <CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc4-40 \
 --config-path <RPC_CONFIG_FILENAME>
 ```
 
 You can use Soroban RPC itself to generate a starter configuration file:
 
 ```bash
-docker run stellar/soroban-rpc:20.0.0-rc3-39 gen-config-file > soroban-rpc-config.toml
+docker run stellar/soroban-rpc:20.0.0-rc4-40 gen-config-file > soroban-rpc-config.toml
 ```
 
 The resulting configuration should look like this:

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -180,7 +180,7 @@ Now you can replace `--network standalone` with `--network futurenet` (or whatev
 
 RPC providers are available with hosted instances for all stages of development and production. The [Provider Directory](rpc-list.mdx) contains links to currently available infrastructure providers.
 
-## Deploy your own RPC instance
+## Deploy Your Own RPC Instance
 
 We recommend the following ways to deploy your own RPC instance:
 
@@ -251,7 +251,7 @@ Even if you're not deploying Soroban RPC using Kubernetes, the manifests generat
 helm template my-rpc stellar/soroban-rpc
 ```
 
-### Docker image
+### Docker Image
 
 If using Kubernetes is not an option, this is the preferred way to deploy your own RPC instance.
 
@@ -279,7 +279,7 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
 DATABASE="sqlite3://stellar.db"
 
-# Stellar Testnet validators
+# Stellar Testnet Validators
 [[HOME_DOMAINS]]
 HOME_DOMAIN="testnet.stellar.org"
 QUALITY="HIGH"

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -5,13 +5,13 @@ title: RPC Usage
 
 The RPC service allows you to communicate directly with Soroban via a [JSON RPC interface](https://soroban.stellar.org/api/).
 
-For example, you can build an application and have it [send a transaction](https://soroban.stellar.org/api/methods/sendTransaction), [get ledger](https://soroban.stellar.org/api/methods/getLedgerEntries) and [event data](https://soroban.stellar.org/api/methods/getEvents) or [simulate transactions](https://soroban.stellar.org/api/methods/simulateTransaction).
+For example, you can build an application and have it [send a transaction](https://soroban.stellar.org/api/methods/sendTransaction), [get ledger](https://soroban.stellar.org/api/methods/getLedgerEntries) and [event data](https://soroban.stellar.org/api/methods/getEvents), or [simulate transactions](https://soroban.stellar.org/api/methods/simulateTransaction).
 
-Alternatively, you can use one of Soroban's [client SDKs](https://soroban.stellar.org/docs/category/sdks) such as the [js-soroban-client](https://soroban.stellar.org/docs/reference/sdks/js), which will need to communicate with an RPC instance to access the network.
+Alternatively, you can use one of Soroban's [client SDKs](https://soroban.stellar.org/docs/category/sdks), such as the [js-soroban-client](https://soroban.stellar.org/docs/reference/sdks/js), which will need to communicate with an RPC instance to access the network.
 
 ## Run Your Own Instance for Development
 
-For local development, we recommend to [download](https://hub.docker.com/r/stellar/quickstart) and run a local instance via [Docker Quickstart](https://github.com/stellar/quickstart) and run a standalone network or communicate with a live development [Testnet].
+For local development, we recommend [downloading](https://hub.docker.com/r/stellar/quickstart) and running a local instance via [Docker Quickstart](https://github.com/stellar/quickstart) and running a standalone network or communicating with a live development [Testnet].
 
 :::caution
 
@@ -23,7 +23,7 @@ The Quickstart image with the RPC service can run on a standard laptop with 8GB 
 
 - [Stellar Core] - Node software that runs the network, coordinates consensus, and finalizes ledgers.
 - [Soroban RPC] server - JSON RPC server for interacting with Soroban contracts.
-- [Horizon server] - HTTP API for access ledger state and historical transactions.
+- [Horizon server] - HTTP API for accessing ledger state and historical transactions.
 - [Friendbot server] - HTTP API for creating and funding new accounts on test networks.
 
 [Stellar Core]: https://github.com/stellar/stellar-core
@@ -33,7 +33,7 @@ The Quickstart image with the RPC service can run on a standard laptop with 8GB 
 
 :::info
 
-It's also possible to run a contract in the local sandbox environment without a network using just Soroban CLI. See [Run on Sandbox] for more details.
+It's also possible to run a contract in the local sandbox environment without a network using just the Soroban CLI. See [Run on Sandbox] for more details.
 
 :::
 
@@ -50,13 +50,13 @@ docker run --rm -it \
     --enable-soroban-rpc
 ```
 
-Once the image is started you can check its status by querying the Horizon API:
+Once the image is started, you can check its status by querying the Horizon API:
 
 ```bash
 curl "http://localhost:8000"
 ```
 
-You can interact with this local node using Soroban CLI. First, add it as a configured network:
+You can interact with this local node using the Soroban CLI. First, add it as a configured network:
 
 ```bash
 soroban config network add standalone \
@@ -72,7 +72,7 @@ soroban config identity generate alice
 
 :::tip Test-only Identities
 
-It's a good practice to never use the same keys for testing and development that you use do for the public Stellar network. Generate new keys for testing and development and avoid ever using them for other purposes.
+It's a good practice to never use the same keys for testing and development that you use for the public Stellar network. Generate new keys for testing and development and avoid using them for other purposes.
 
 :::
 
@@ -109,14 +109,14 @@ soroban contract invoke \
     --to friend
 ```
 
-When you're done with your Standalone node, you can close it with <kbd>ctrl</kbd><kbd>c</kbd> (not <kbd>cmd</kbd>). This will fully remove the container (that's what the `--rm` option to the `docker` command does), which means you will need to re-deploy your contract and re-fund your identity next time you start it. If you work with local nodes often, you may want to create scripts to make these initialization steps easier. For example, see the [example dapp's `initialize.sh`](https://github.com/stellar/soroban-example-dapp/blob/abdac3afdb6c410cc426831ece93371c1a27347d/initialize.sh).
+When you're done with your Standalone node, you can close it with <kbd>ctrl</kbd><kbd>c</kbd> (not <kbd>cmd</kbd>). This will fully remove the container (that's what the `--rm` option to the `docker` command does), which means you will need to re-deploy your contract and re-fund your identity the next time you start it. If you work with local nodes often, you may want to create scripts to make these initialization steps easier. For example, see the [example dapp's `initialize.sh`](https://github.com/stellar/soroban-example-dapp/blob/abdac3afdb6c410cc426831ece93371c1a27347d/initialize.sh).
 
 [Testnet]: testnet
 [Run on Sandbox]: ../getting-started/hello-world#run-on-sandbox
 
 ### Testnet
 
-Running your own Testnet node works much the same way as running a Quickstart node, described above. You will need minor modifications for a few commands. First, you need `--testnet` for the docker instance, rather than `--standalone`:
+Running your own Testnet node works much the same way as running a Quickstart node, as described above. You will need minor modifications for a few commands. First, you need `--testnet` for the docker instance, rather than `--standalone`:
 
 ```bash
 docker run --rm -it \
@@ -135,7 +135,7 @@ soroban config network add testnet \
     --network-passphrase "Test SDF Network ; September 2015"
 ```
 
-Replace `testnet` in that command with the name of your choice, if you want to leave the name `testnet` available for use with a public RPC provider (see below). Or make clever use of `--global` configs for public providers and local configs (made with the undecorated `network add` command above) for local nodes.
+Replace `testnet` in that command with the name of your choice if you want to leave the name `testnet` available for use with a public RPC provider (see below). Or make clever use of `--global` configs for public providers and local configs (made with the undecorated `network add` command above) for local nodes.
 
 The `alice` identity suggested for your Standalone network will still work here, since it's just a public/private keypair, but you'll need to remember to fund it for the Testnet network:
 
@@ -147,7 +147,7 @@ Now you can replace `--network standalone` with `--network testnet` (or whatever
 
 ### Futurenet
 
-You can also develop your Soroban contracts against the Futurenet network. You may choose this if you want to test more bleeding edge features that haven't made it to the Testnet yet. Running your own Futurenet node works just like running a Testnet node, described above.
+You can also develop your Soroban contracts against the Futurenet network. You may choose this if you want to test more bleeding-edge features that haven't made it to the Testnet yet. Running your own Futurenet node works just like running a Testnet node, as described above.
 
 ```bash
 docker run --rm -it \
@@ -215,7 +215,7 @@ helm install my-rpc stellar/soroban-rpc \
 
 This example of Helm chart usage highlights some key aspects:
 
-- Set the `global.image.sorobanRpc.tag` to a tag from the [soroban-rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [the releases page](./releases) to find the correct tag to use for the Soroban release you are running.
+- Set the `global.image.sorobanRpc.tag` to a tag from the [soroban-rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [the releases page](./releases) to find the correct tag for the Soroban release you are running.
 
 - The RPC server stores a revolving window of recent data from network ledgers to disk. The size of that data varies depending on the network and its transaction volumes, but it has an estimated range between 10 to 100 MB. To ensure the RPC pod has consistent access to disk storage space and read/write throughput, this example demonstrates how to optionally enable the Helm chart deployment to use a `PersistentVolumeClaim` (PVC) of 100MB from `default` storage class on Kubernetes by enabling these persistence parameters:
 
@@ -226,13 +226,13 @@ This example of Helm chart usage highlights some key aspects:
 
 By default, this is disabled (`sorobanRpc.persistence.enabled=false`) and the RPC deployment will use ephemeral pod storage via `emptyDir`, which will likely be adequate for `futurenet` and `testnet` transaction volumes. However, it's worth highlighting the trade-off of not having storage limitations of the cluster enforced (likely below 100MB).
 
-- Network presets are defined in [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other "canned" `values.yaml` files which have been published for other networks. For example, there is a [`testnet-values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) file to configure deployment of RPC server with the `testnet` network. Include this `--values` parameter in your `helm install` to specify the desired network:
+- Network presets are defined in [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other "canned" `values.yaml` files which have been published for other networks. For example, there is a [`testnet-values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) file to configure the deployment of the RPC server with the `testnet` network. Include this `--values` parameter in your `helm install` to specify the desired network:
 
 ```bash
 --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/testnet-values.yaml
 ```
 
-- Configuring RPC to use other custom networks can be accomplished by downloading the [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) locally and updating settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig`. This is applicable when needing to connect to specific networks other than the existing files like `values.yaml` available, such as your own standalone network. Include the local `values.yaml` in `helm install`:
+- Configuring RPC to use other custom networks can be accomplished by downloading the [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) locally and updating settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig`. This is applicable when connecting to specific networks other than the existing files like `values.yaml` available, such as your own standalone network. Include the local `values.yaml` in `helm install`:
 
 ```bash
 --values my-custom-values.yaml
@@ -515,7 +515,7 @@ Note that the above generated configuration contains the default values and you 
 
 ### Build From Source
 
-Instructions for building Soroban RPC from source can be found [here](https://github.com/stellar/soroban-tools/blob/main/cmd/soroban-rpc/README.md)
+Instructions for building Soroban RPC from source can be found [here](https://github.com/stellar/soroban-tools/blob/main/cmd/soroban-rpc/README.md).
 
 ### Hardware Requirements
 
@@ -545,7 +545,7 @@ See the tip above about command expansion (that's the note about `$(...)`) if yo
 
 :::caution
 
-When interacting with the network in production you should run your own soroban-rpc or use a third party infrastructure provider.
+When interacting with the network in production you should run your own soroban-rpc or use a third-party infrastructure provider.
 
 :::
 
@@ -584,7 +584,7 @@ You should get back an HTTP 200 status response if the instance is healthy:
 
 ### System Test Docker Image
 
-This test will compile, deploy, and invoke example contracts to the network which your RPC instance is connected to. Here is an example for verifying your instance if it is connected to Testnet:
+This test will compile, deploy, and invoke example contracts to the network to which your RPC instance is connected to. Here is an example for verifying your instance if it is connected to Testnet:
 
 ```bash
 docker run --rm -t --name e2e_test \
@@ -599,8 +599,8 @@ docker.io/stellar/system-test:soroban-preview11 \
 
 Make sure you configure the system test correctly:
 
-- Use a published [system test tag](https://hub.docker.com/r/stellar/system-test/tags) which aligns with the deployed Soroban RPC release version. For each release, there will be two tags published for different CPU architectures. Make sure to use the tag that matches your host machine's CPU architecture:
-  - `docker.io/stellar/system-test:<release name>` for machines with AMD/Intel based CPUs
+- Use a published [system test tag](https://hub.docker.com/r/stellar/system-test/tags) that aligns with the deployed Soroban RPC release version. For each release, there will be two tags published for different CPU architectures. Make sure to use the tag that matches your host machine's CPU architecture:
+  - `docker.io/stellar/system-test:<release name>` for machines with AMD/Intel-based CPUs
   - `docker.io/stellar/system-test:<release name>-arm64` for machines with ARM CPUs
 - Set `--TargetNetworkRPCURL` to your RPC HTTP URL
 - Set `--TargetNetworkPassphrase` to the same network your RPC instance is connected to:

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -9,13 +9,15 @@ For example, you can build an application and have it [send a transaction](https
 
 Alternatively, you can use one of Soroban's [client SDKs](https://soroban.stellar.org/docs/category/sdks) such as the [js-soroban-client](https://soroban.stellar.org/docs/reference/sdks/js), which will need to communicate with an RPC instance to access the network.
 
-## Run Your Own Instance
+## Run Your Own Instance for Development
 
-[Download](https://hub.docker.com/r/stellar/quickstart) and run a local instance via [Docker Quickstart](https://github.com/stellar/quickstart) and run a standalone network or communicate with a live development [Testnet].
+For local development, we recommend to [download](https://hub.docker.com/r/stellar/quickstart) and run a local instance via [Docker Quickstart](https://github.com/stellar/quickstart) and run a standalone network or communicate with a live development [Testnet].
 
-For local development, an RPC service can run on a standard laptop with 16GB of RAM and has minimal storage and CPU requirements.
+:::caution
+We don't recommend running the Quickstart image in production. See the [deploy your own RPC instance](#deploy-your-own-rpc-instance) section.
+:::
 
-The Quickstart image is a single container that runs everything you need to test against a fully featured network. It contains:
+The Quickstart image with the RPC service can run on a standard laptop with 8GB of RAM and has minimal storage and CPU requirements. It is a single container that runs everything you need to test against a fully featured network. It contains:
 
 - [Stellar Core] - Node software that runs the network, coordinates consensus, and finalizes ledgers.
 - [Soroban RPC] server - JSON RPC server for interacting with Soroban contracts.
@@ -172,14 +174,25 @@ RPC providers are available with hosted instances for all stages of development 
 
 ## Deploy your own RPC instance
 
-If your target deployment environment includes Kubernetes infrastructure, you can utilize [soroban rpc helm chart](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc) for an automated deployment on the cluster. Install the [Helm cli tool](https://helm.sh/docs/intro/install/), minimum of version 3 if you haven't already on your workstation. Next, add the Stellar repo to the helm client's list of repos, update it to the latest published versions:
+We recommend the following ways to deploy your own RPC instance:
+
+1. Deploy to Kubernetes using [Helm](https://helm.sh/docs/intro/install/)
+2. Run the [soroban-rpc docker image](https://hub.docker.com/r/stellar/soroban-rpc) directly
+
+### Kubernetes With Helm
+
+If your deployment environment includes Kubernetes infrastructure, this is the preferred way to deploy your RPC instance. Here’s what you need to do:
+
+1. Install the [Helm CLI tool](https://helm.sh/docs/intro/install/) (minimum version 3)
+
+2. Add the Stellar repo to the helm client's list of repos, update it to the latest published versions
 
 ```bash
 helm repo add stellar https://helm.stellar.org/charts
 helm repo update stellar
 ```
 
-Deploy rpc to kubernetes using the helm chart:
+3. Deploy the RPC instance to Kubernetes using [our Helm chart](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc):
 
 ```bash
 helm install my-rpc stellar/soroban-rpc \
@@ -192,43 +205,316 @@ helm install my-rpc stellar/soroban-rpc \
 --set sorobanRpc.resources.limits.memory=2560Mi
 ```
 
-This example of helm chart usage, highlights some key aspects:
+This example of Helm chart usage highlights some key aspects:
 
-- Set the `global.image.sorobanRpc.tag` to a tag from the [soroban rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [the releases page](./releases) to find the correct tag to use for the soroban release you are running.
+- Set the `global.image.sorobanRpc.tag` to a tag from the [soroban-rpc dockerhub repo](https://hub.docker.com/r/stellar/soroban-rpc) for the image version you want to run. Refer to [the releases page](./releases) to find the correct tag to use for the Soroban release you are running.
 
-- The RPC server stores a revolving window of recent data from network ledgers to disk. The sizing of that data will vary depending on the network and it's transaction volumes, estimated range between 10 to 100 MB. To ensure the RPC pod has consistent access to disk storage space and read/write throughput, this example demonstrates how to optionally enable the helm chart deployment to use a `PersistentVolumeClaim` (PVC) of 100MB from `default` storage class on kubernetes by enabling these persistence parameters:
+- The RPC server stores a revolving window of recent data from network ledgers to disk. The size of that data varies depending on the network and its transaction volumes, but it has an estimated range between 10 to 100 MB. To ensure the RPC pod has consistent access to disk storage space and read/write throughput, this example demonstrates how to optionally enable the Helm chart deployment to use a `PersistentVolumeClaim` (PVC) of 100MB from `default` storage class on Kubernetes by enabling these persistence parameters:
 
 ```bash
 --set sorobanRpc.persistence.enabled=true
 --set sorobanRpc.persistence.storageClass=default
 ```
 
-By default, this is disabled (`sorobanRpc.persistence.enabled=false`) and the RPC deployment will use ephemeral pod storage via `emptyDir` which will likely be adequate for `futurenet` and `testnet` transaction volumes, but it's worth highlighting the trade-off, which is size limitations enforced from the cluster, most likely lower than 100MB.
+By default, this is disabled (`sorobanRpc.persistence.enabled=false`) and the RPC deployment will use ephemeral pod storage via `emptyDir`, which will likely be adequate for `futurenet` and `testnet` transaction volumes. However, it's worth highlighting the trade-off of not having storage limitations of the cluster enforced (likely below 100MB).
 
-- Network presets are defined in [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other "canned" `values.yaml` files which have been published for other networks. For example, there is a [`testnet-values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) file to configure deployment of RPC server with the `testnet` network. Include this `--values` parameter in your `helm install` your to specify the desired network:
+- Network presets are defined in [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml), which currently sets network configuration specific to `futurenet`. You can override this default and use other "canned" `values.yaml` files which have been published for other networks. For example, there is a [`testnet-values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/testnet-values.yaml) file to configure deployment of RPC server with the `testnet` network. Include this `--values` parameter in your `helm install` to specify the desired network:
 
 ```bash
 --values https://raw.githubusercontent.com/stellar/helm-charts/main/charts/soroban-rpc/testnet-values.yaml
 ```
 
-- Configuring RPC to use other custom networks can be accomplished by downloading the [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) locally and updating settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig`. This is applicable when needing to connect to specific networks other than the "canned" `values.yaml` files available, such as your own standalone network. Include the local `values.yaml` in `helm install`:
+- Configuring RPC to use other custom networks can be accomplished by downloading the [`values.yaml`](https://github.com/stellar/helm-charts/blob/main/charts/soroban-rpc/values.yaml) locally and updating settings under `sorobanRpc.sorobanRpcConfig` and `sorobanRpc.coreConfig`. This is applicable when needing to connect to specific networks other than the existing files like `values.yaml` available, such as your own standalone network. Include the local `values.yaml` in `helm install`:
 
 ```bash
 --values my-custom-values.yaml
 ```
 
-- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config, if defined, ensure that the defaults provide at least minimum RPC server resource limits of `2.5Gi` of memory and `1` CPU. Otherwise, include the limits explicitly on the `helm install` command via the `sorobanRpc.resources.limits.*` parameters.
+- Verify the `LimitRange` defaults in the target namespace in kubernetes for deployment. `LimitRange` is optional on the cluster config. If defined, ensure that the defaults provide at least minimum RPC server resource limits of `2.5Gi` of memory and `1` CPU. Otherwise, include the limits explicitly on the `helm install` command via the `sorobanRpc.resources.limits.*` parameters:
 
 ```bash
 --set sorobanRpc.resources.limits.cpu=1
 --set sorobanRpc.resources.limits.memory=2560Mi
 ```
 
-If kubernetes is not an option, the manifests generated by the charts may still be a good reference for showing how to configure and run Soroban RPC as a docker container. Just run the `helm template` command to print the container configuration to screen:
+Even if you're not deploying Soroban RPC using Kubernetes, the manifests generated by the charts may still be a good reference for showing how to configure and run Soroban RPC as a docker container. Just run the `helm template` command to print the container configuration to screen:
 
 ```bash
 helm template my-rpc stellar/soroban-rpc
 ```
+
+### Docker image
+
+If using Kubernetes is not an option, this is the preffered way to deploy your own RPC instance.
+
+:::caution
+Although we have a [Quickstart Image](https://github.com/stellar/quickstart), it's for local development and testing only. It is not suitable for production-grade deployments.
+:::
+
+Here's how to run the [soroban-rpc docker image](https://hub.docker.com/r/stellar/soroban-rpc):
+
+1. Pull the image at the version you'd like to run from [the tags](https://hub.docker.com/r/stellar/soroban-rpc/tags):
+
+```bash
+docker pull stellar/soroban-rpc:20.0.0-rc3-39
+```
+
+2. Create a configuration file for [Stellar Core](https://github.com/stellar/stellar-core). Here is a sample configuration file for testnet:
+
+```toml
+HTTP_PORT=11626
+PUBLIC_HTTP_PORT=false
+
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+DATABASE="sqlite3://stellar.db"
+
+# Stellar Testnet validators
+[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="sdftest1"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS="core-testnet1.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdftest2"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS="core-testnet2.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdftest3"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
+ADDRESS="core-testnet3.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
+```
+
+3. Run the image, making sure to [mount a volume](https://docs.docker.com/storage/volumes/) to your container where the above configuration is stored. An example for testnet:
+
+```bash
+docker run -p 8001:8001 -p 8000:8000 \
+-v <STELLAR_CORE_CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc3-39 \
+--captive-core-config-path="/config/<STELLAR_CORE_CONFIG_PATH>" \
+--captive-core-storage-path="/var/lib/stellar/captive-core" \
+--captive-core-use-db=true \
+--stellar-core-binary-path="/usr/bin/stellar-core" \
+--db-path="/var/lib/stellar/soroban-rpc-db.sqlite" \
+--stellar-captive-core-http-port=11626 \
+--friendbot-url="https://friendbot-testnet.stellar.org/" \
+--network-passphrase="Test SDF Network ; September 2015" \
+--history-archive-urls="https://history.stellar.org/prd/core-testnet/core_testnet_001" \
+--admin-endpoint="0.0.0.0:8001" \
+--endpoint="0.0.0.0:8000"
+```
+
+#### Configuration
+
+For production, we recommend running Soroban RPC with a [TOML](https://toml.io/en/) configuration file rather than CLI flags. This is similar to creating a configuration file for Stellar-Core as we did previously. For example, using [our docker image](https://hub.docker.com/r/stellar/soroban-rpc):
+
+```bash
+docker run -p 8001:8001 -p 8000:8000 \
+-v <CONFIG_FOLDER>:/config stellar/soroban-rpc:20.0.0-rc3-39 \
+--config-path <RPC_CONFIG_FILENAME>
+```
+
+You can use Soroban RPC itself to generate a starter configuration file:
+
+```bash
+docker run stellar/soroban-rpc:20.0.0-rc3-39 gen-config-file > soroban-rpc-config.toml
+```
+
+The resulting configuration should look like this:
+
+```toml
+# Admin endpoint to listen and serve on. WARNING: this should not be accessible
+# from the Internet and does not use TLS. "" (default) disables the admin server
+# ADMIN_ENDPOINT = "0.0.0.0:8001"
+
+# path to additional configuration for the Stellar Core configuration file used
+# by captive core. It must, at least, include enough details to define a quorum
+# set
+# CAPTIVE_CORE_CONFIG_PATH = ""
+
+# Storage location for Captive Core bucket data
+CAPTIVE_CORE_STORAGE_PATH = "/"
+
+# informs captive core to use on disk mode. the db will by default be created in
+# current runtime directory of soroban-rpc, unless DATABASE=<path> setting is
+# present in captive core config file.
+# CAPTIVE_CORE_USE_DB = false
+
+# establishes how many ledgers exist between checkpoints, do NOT change this
+# unless you really know what you are doing
+CHECKPOINT_FREQUENCY = 64
+
+# SQLite DB path
+DB_PATH = "soroban_rpc.sqlite"
+
+# Default cap on the amount of events included in a single getEvents response
+DEFAULT_EVENTS_LIMIT = 100
+
+# Endpoint to listen and serve on
+ENDPOINT = "0.0.0.0:8000"
+
+# configures the event retention window expressed in number of ledgers, the
+# default value is 17280 which corresponds to about 24 hours of history
+EVENT_RETENTION_WINDOW = 17280
+
+# The friendbot URL to be returned by getNetwork endpoint
+# FRIENDBOT_URL = ""
+
+# comma-separated list of stellar history archives to connect with
+HISTORY_ARCHIVE_URLS = []
+
+# Ingestion Timeout when bootstrapping data (checkpoint and in-memory
+# initialization) and preparing ledger reads
+INGESTION_TIMEOUT = "30m0s"
+
+# format used for output logs (json or text)
+# LOG_FORMAT = "text"
+
+# minimum log severity (debug, info, warn, error) to log
+LOG_LEVEL = "info"
+
+# Maximum amount of events allowed in a single getEvents response
+MAX_EVENTS_LIMIT = 10000
+
+# The maximum duration of time allowed for processing a getEvents request. When
+# that time elapses, the rpc server would return -32001 and abort the request's
+# execution
+MAX_GET_EVENTS_EXECUTION_DURATION = "10s"
+
+# The maximum duration of time allowed for processing a getHealth request. When
+# that time elapses, the rpc server would return -32001 and abort the request's
+# execution
+MAX_GET_HEALTH_EXECUTION_DURATION = "5s"
+
+# The maximum duration of time allowed for processing a getLatestLedger request.
+# When that time elapses, the rpc server would return -32001 and abort the
+# request's execution
+MAX_GET_LATEST_LEDGER_EXECUTION_DURATION = "5s"
+
+# The maximum duration of time allowed for processing a getLedgerEntries
+# request. When that time elapses, the rpc server would return -32001 and abort
+# the request's execution
+MAX_GET_LEDGER_ENTRIES_EXECUTION_DURATION = "5s"
+
+# The maximum duration of time allowed for processing a getNetwork request. When
+# that time elapses, the rpc server would return -32001 and abort the request's
+# execution
+MAX_GET_NETWORK_EXECUTION_DURATION = "5s"
+
+# The maximum duration of time allowed for processing a getTransaction request.
+# When that time elapses, the rpc server would return -32001 and abort the
+# request's execution
+MAX_GET_TRANSACTION_EXECUTION_DURATION = "5s"
+
+# maximum ledger latency (i.e. time elapsed since the last known ledger closing
+# time) considered to be healthy (used for the /health endpoint)
+MAX_HEALTHY_LEDGER_LATENCY = "30s"
+
+# The max request execution duration is the predefined maximum duration of time
+# allowed for processing a request. When that time elapses, the server would
+# return 504 and abort the request's execution
+MAX_REQUEST_EXECUTION_DURATION = "25s"
+
+# The maximum duration of time allowed for processing a sendTransaction request.
+# When that time elapses, the rpc server would return -32001 and abort the
+# request's execution
+MAX_SEND_TRANSACTION_EXECUTION_DURATION = "15s"
+
+# The maximum duration of time allowed for processing a simulateTransaction
+# request. When that time elapses, the rpc server would return -32001 and abort
+# the request's execution
+MAX_SIMULATE_TRANSACTION_EXECUTION_DURATION = "15s"
+
+# Network passphrase of the Stellar network transactions should be signed for.
+# Commonly used values are "Test SDF Future Network ; October 2022", "Test SDF
+# Network ; September 2015" and "Public Global Stellar Network ; September 2015"
+# NETWORK_PASSPHRASE = ""
+
+# Number of workers (read goroutines) used to compute preflights for the
+# simulateTransaction endpoint. Defaults to the number of CPUs.
+PREFLIGHT_WORKER_COUNT = 16
+
+# Maximum number of outstanding preflight requests for the simulateTransaction
+# endpoint. Defaults to the number of CPUs.
+PREFLIGHT_WORKER_QUEUE_SIZE = 16
+
+# Maximum number of outstanding GetEvents requests
+REQUEST_BACKLOG_GET_EVENTS_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding GetHealth requests
+REQUEST_BACKLOG_GET_HEALTH_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding GetLatestsLedger requests
+REQUEST_BACKLOG_GET_LATEST_LEDGER_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding GetLedgerEntries requests
+REQUEST_BACKLOG_GET_LEDGER_ENTRIES_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding GetNetwork requests
+REQUEST_BACKLOG_GET_NETWORK_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding GetTransaction requests
+REQUEST_BACKLOG_GET_TRANSACTION_QUEUE_LIMIT = 1000
+
+# Maximum number of outstanding requests
+REQUEST_BACKLOG_GLOBAL_QUEUE_LIMIT = 5000
+
+# Maximum number of outstanding SendTransaction requests
+REQUEST_BACKLOG_SEND_TRANSACTION_QUEUE_LIMIT = 500
+
+# Maximum number of outstanding SimulateTransaction requests
+REQUEST_BACKLOG_SIMULATE_TRANSACTION_QUEUE_LIMIT = 100
+
+# The request execution warning threshold is the predetermined maximum duration
+# of time that a request can take to be processed before a warning would be
+# generated
+REQUEST_EXECUTION_WARNING_THRESHOLD = "5s"
+
+# HTTP port for Captive Core to listen on (0 disables the HTTP server)
+STELLAR_CAPTIVE_CORE_HTTP_PORT = 11626
+
+# path to stellar core binary
+STELLAR_CORE_BINARY_PATH = "/usr/bin/stellar-core"
+
+# Timeout used when submitting requests to stellar-core
+STELLAR_CORE_TIMEOUT = "2s"
+
+# URL used to query Stellar Core (local captive core by default)
+# STELLAR_CORE_URL = ""
+
+# Enable strict toml configuration file parsing. This will prevent unknown
+# fields in the config toml from being parsed.
+# STRICT = false
+
+# configures the transaction retention window expressed in number of ledgers,
+# the default value is 1440 which corresponds to about 2 hours of history
+TRANSACTION_RETENTION_WINDOW = 1440
+```
+
+Note that the above generated configuration contains the default values and you need to substitute them with proper values to run the image.
+
+### Build From Source
+
+Instructions for building Soroban RPC from source can be found [here](https://github.com/stellar/soroban-tools/blob/main/cmd/soroban-rpc/README.md)
+
+### Hardware Requirements
+
+For deployments expecting up to 1000 requests per second to Soroban RPC, we recommend at least 4GB of RAM and at least a dual core CPU with a 2.4GHz clock speed.
+
+For deployments expecting 1000-10000+ requests per second to Soroban RPC, we recommend at least 8GB of RAM and at least a quad core CPU with a 2.4GHz clock speed.
+
+For all deployments, we recommend at least 10GB of disk/storage space.
+
 
 ## Use the RPC Instance
 
@@ -251,3 +537,96 @@ See the tip above about command expansion (that's the note about `$(...)`) if yo
 :::caution
 When interacting with the network in production you should run your own soroban-rpc or use a third party infrastructure provider.
 :::
+
+## Verify the RPC Instance
+
+After installation, it will be worthwhile to verify the installation of Soroban RPC is healthy. There are two methods:
+
+1. Access the health status endpoint of the JSON RPC service using an HTTP client
+2. Use our pre-built [System Test Docker image](https://hub.docker.com/r/stellar/system-test/tags) as a tool to run a set of live tests against Soroban RPC
+
+### Health Status Endpoint
+
+If you send a JSON RPC HTTP request to your running instance of Soroban RPC:
+
+```bash
+curl --location 'http://localhost:8000' \
+--header 'Content-Type: application/json' \
+--data '{
+"jsonrpc":"2.0",
+"id":2,
+"method":"getHealth"
+}'
+```
+
+You should get back an HTTP 200 status response if the instance is healthy:
+
+```json
+{ 
+   "jsonrpc":"2.0",
+   "id":2,
+    "result":{
+       "status":"healthy"
+    }
+}
+```
+
+### System Test Docker Image
+
+This test will compile, deploy, and invoke example contracts to the network which your RPC instance is connected to. Here is an example for verifying your instance if it is connected to testnet:
+
+```bash
+docker run --rm -t --name e2e_test \
+docker.io/stellar/system-test:soroban-preview11 \
+--VerboseOutput true \
+--TargetNetworkRPCURL <your rpc url here> \
+--TargetNetworkPassphrase "Test SDF Network ; September 2015" \
+--TargetNetworkTestAccountSecret <your test account strkey encoded key here > \
+--TargetNetworkTestAccountPublic <your test account strkey encoded pubkey here> \
+--SorobanExamplesGitHash v20.0.0-rc2
+```
+
+Make sure you configure the system test correctly:
+
+- Use a published [system test tag](https://hub.docker.com/r/stellar/system-test/tags) which aligns with the deployed Soroban RPC release version. For each release, there will be two tags published for different CPU architectures. Make sure to use the tag that matches your host machine's CPU architecture:
+    - `docker.io/stellar/system-test:<release name>` for machines with AMD/Intel based CPUs
+    - `docker.io/stellar/system-test:<release name>-arm64` for machines with ARM CPUs
+- Set `--TargetNetworkRPCURL` to your RPC HTTP URL
+- Set `--TargetNetworkPassphrase` to the same network your RPC instance is connected to:
+    - `"Test SDF Network ; September 2015"` for testnet
+    - `"Test SDF Future Network ; October 2022"` for futurenet
+- Set `--SorobanExamplesGitHash` to the corresponding release tag on the [Soroban Examples repo](https://github.com/stellar/soroban-examples/tags)
+- Create and fund an account to be used for test purposes on the same network your RPC instance is connected to
+    - This account needs a small XLM balance to submit Soroban transactions
+    - Tests can be run repeatedly with the same account
+    - Set `--TargetNetworkTestAccountPublic` to the `Strkey` encoded public key of the account
+    - Set `--TargetNetworkTestAccountSecret` to the `Strkey` encoded secret for the account
+
+## Monitor the RPC Instance
+
+If you run Soroban RPC with the `--admin-endpoint` configured and [expose the port](https://docs.docker.com/engine/reference/commandline/run/#publish), you'll have access to the [Prometheus](https://prometheus.io/) metrics via the `/metrics` endpoint. For example, if the admin endpoint is `0.0.0.0:8001` and you're running the Soroban RPC Docker image:
+
+```bash
+curl localhost:8001/metrics
+```
+
+You will see many of the default Go and Process metrics (prefixed by `go_` and `process_` respectively) such as memory usage, CPU usage, number of threads, etc.
+
+We also expose metrics related to Soroban RPC (prefixed by `soroban_rpc`). There are many, but some notable ones are:
+
+- `soroban_rpc_transactions_count` - count of transactions ingested with a sliding window of 10m
+- `soroban_rpc_events_count` - count of events ingested with a sliding window of 10m
+- `soroban_rpc_ingest_local_latest_ledger` - latest ledger ingested
+- `soroban_rpc_db_round_trip_time_seconds` - time required to run `SELECT 1` query in the DATABASE
+
+Soroban RPC also provides logging to console for:
+- Startup activity
+- Ingesting, applying, and closing ledgers
+- Handling JSON RPC requests
+- Any errors
+
+The logs have the format:
+
+```
+time=<timestamp in YYYY-MM-DDTHH:MM:SS.000Z format> level=<debug|info|error> msg=<Actual message> pid=<process ID> subservice=<optional if coming from subservice>
+```

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -515,7 +515,6 @@ For deployments expecting 1000-10000+ requests per second to Soroban RPC, we rec
 
 For all deployments, we recommend at least 10GB of disk/storage space.
 
-
 ## Use the RPC Instance
 
 You can configure Soroban CLI to use a remote RPC endpoint:
@@ -562,12 +561,12 @@ curl --location 'http://localhost:8000' \
 You should get back an HTTP 200 status response if the instance is healthy:
 
 ```json
-{ 
-   "jsonrpc":"2.0",
-   "id":2,
-    "result":{
-       "status":"healthy"
-    }
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "status": "healthy"
+  }
 }
 ```
 
@@ -589,18 +588,18 @@ docker.io/stellar/system-test:soroban-preview11 \
 Make sure you configure the system test correctly:
 
 - Use a published [system test tag](https://hub.docker.com/r/stellar/system-test/tags) which aligns with the deployed Soroban RPC release version. For each release, there will be two tags published for different CPU architectures. Make sure to use the tag that matches your host machine's CPU architecture:
-    - `docker.io/stellar/system-test:<release name>` for machines with AMD/Intel based CPUs
-    - `docker.io/stellar/system-test:<release name>-arm64` for machines with ARM CPUs
+  - `docker.io/stellar/system-test:<release name>` for machines with AMD/Intel based CPUs
+  - `docker.io/stellar/system-test:<release name>-arm64` for machines with ARM CPUs
 - Set `--TargetNetworkRPCURL` to your RPC HTTP URL
 - Set `--TargetNetworkPassphrase` to the same network your RPC instance is connected to:
-    - `"Test SDF Network ; September 2015"` for testnet
-    - `"Test SDF Future Network ; October 2022"` for futurenet
+  - `"Test SDF Network ; September 2015"` for testnet
+  - `"Test SDF Future Network ; October 2022"` for futurenet
 - Set `--SorobanExamplesGitHash` to the corresponding release tag on the [Soroban Examples repo](https://github.com/stellar/soroban-examples/tags)
 - Create and fund an account to be used for test purposes on the same network your RPC instance is connected to
-    - This account needs a small XLM balance to submit Soroban transactions
-    - Tests can be run repeatedly with the same account
-    - Set `--TargetNetworkTestAccountPublic` to the `Strkey` encoded public key of the account
-    - Set `--TargetNetworkTestAccountSecret` to the `Strkey` encoded secret for the account
+  - This account needs a small XLM balance to submit Soroban transactions
+  - Tests can be run repeatedly with the same account
+  - Set `--TargetNetworkTestAccountPublic` to the `Strkey` encoded public key of the account
+  - Set `--TargetNetworkTestAccountSecret` to the `Strkey` encoded secret for the account
 
 ## Monitor the RPC Instance
 
@@ -620,6 +619,7 @@ We also expose metrics related to Soroban RPC (prefixed by `soroban_rpc`). There
 - `soroban_rpc_db_round_trip_time_seconds` - time required to run `SELECT 1` query in the DATABASE
 
 Soroban RPC also provides logging to console for:
+
 - Startup activity
 - Ingesting, applying, and closing ledgers
 - Handling JSON RPC requests

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -247,7 +247,7 @@ helm template my-rpc stellar/soroban-rpc
 
 ### Docker image
 
-If using Kubernetes is not an option, this is the preffered way to deploy your own RPC instance.
+If using Kubernetes is not an option, this is the preferred way to deploy your own RPC instance.
 
 :::caution
 Although we have a [Quickstart Image](https://github.com/stellar/quickstart), it's for local development and testing only. It is not suitable for production-grade deployments.

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -14,7 +14,9 @@ Alternatively, you can use one of Soroban's [client SDKs](https://soroban.stella
 For local development, we recommend to [download](https://hub.docker.com/r/stellar/quickstart) and run a local instance via [Docker Quickstart](https://github.com/stellar/quickstart) and run a standalone network or communicate with a live development [Testnet].
 
 :::caution
+
 We don't recommend running the Quickstart image in production. See the [deploy your own RPC instance](#deploy-your-own-rpc-instance) section.
+
 :::
 
 The Quickstart image with the RPC service can run on a standard laptop with 8GB of RAM and has minimal storage and CPU requirements. It is a single container that runs everything you need to test against a fully featured network. It contains:

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -592,8 +592,8 @@ docker.io/stellar/system-test:soroban-preview11 \
 --VerboseOutput true \
 --TargetNetworkRPCURL <your rpc url here> \
 --TargetNetworkPassphrase "Test SDF Network ; September 2015" \
---TargetNetworkTestAccountSecret <your test account strkey encoded key here > \
---TargetNetworkTestAccountPublic <your test account strkey encoded pubkey here> \
+--TargetNetworkTestAccountSecret <your test account StrKey encoded key here > \
+--TargetNetworkTestAccountPublic <your test account StrKey encoded pubkey here> \
 --SorobanExamplesGitHash v20.0.0-rc2
 ```
 
@@ -610,8 +610,8 @@ Make sure you configure the system test correctly:
 - Create and fund an account to be used for test purposes on the same network your RPC instance is connected to
   - This account needs a small XLM balance to submit Soroban transactions
   - Tests can be run repeatedly with the same account
-  - Set `--TargetNetworkTestAccountPublic` to the `Strkey` encoded public key of the account
-  - Set `--TargetNetworkTestAccountSecret` to the `Strkey` encoded secret for the account
+  - Set `--TargetNetworkTestAccountPublic` to the `StrKey` encoded public key of the account
+  - Set `--TargetNetworkTestAccountSecret` to the `StrKey` encoded secret for the account
 
 ## Monitor the RPC Instance
 

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -269,7 +269,7 @@ Here's how to run the [soroban-rpc docker image](https://hub.docker.com/r/stella
 docker pull stellar/soroban-rpc:20.0.0-rc3-39
 ```
 
-2. Create a configuration file for [Stellar Core](https://github.com/stellar/stellar-core). Here is a sample configuration file for testnet:
+2. Create a configuration file for [Stellar Core](https://github.com/stellar/stellar-core). Here is a sample configuration file for Testnet:
 
 ```toml
 HTTP_PORT=11626
@@ -306,7 +306,7 @@ ADDRESS="core-testnet3.stellar.org"
 HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
 ```
 
-3. Run the image, making sure to [mount a volume](https://docs.docker.com/storage/volumes/) to your container where the above configuration is stored. An example for testnet:
+3. Run the image, making sure to [mount a volume](https://docs.docker.com/storage/volumes/) to your container where the above configuration is stored. An example for Testnet:
 
 ```bash
 docker run -p 8001:8001 -p 8000:8000 \
@@ -584,7 +584,7 @@ You should get back an HTTP 200 status response if the instance is healthy:
 
 ### System Test Docker Image
 
-This test will compile, deploy, and invoke example contracts to the network which your RPC instance is connected to. Here is an example for verifying your instance if it is connected to testnet:
+This test will compile, deploy, and invoke example contracts to the network which your RPC instance is connected to. Here is an example for verifying your instance if it is connected to Testnet:
 
 ```bash
 docker run --rm -t --name e2e_test \
@@ -604,8 +604,8 @@ Make sure you configure the system test correctly:
   - `docker.io/stellar/system-test:<release name>-arm64` for machines with ARM CPUs
 - Set `--TargetNetworkRPCURL` to your RPC HTTP URL
 - Set `--TargetNetworkPassphrase` to the same network your RPC instance is connected to:
-  - `"Test SDF Network ; September 2015"` for testnet
-  - `"Test SDF Future Network ; October 2022"` for futurenet
+  - `"Test SDF Network ; September 2015"` for Testnet
+  - `"Test SDF Future Network ; October 2022"` for Futurenet
 - Set `--SorobanExamplesGitHash` to the corresponding release tag on the [Soroban Examples repo](https://github.com/stellar/soroban-examples/tags)
 - Create and fund an account to be used for test purposes on the same network your RPC instance is connected to
   - This account needs a small XLM balance to submit Soroban transactions

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -32,7 +32,9 @@ The Quickstart image with the RPC service can run on a standard laptop with 8GB 
 [Friendbot server]: https://github.com/stellar/go/tree/master/services/friendbot
 
 :::info
+
 It's also possible to run a contract in the local sandbox environment without a network using just Soroban CLI. See [Run on Sandbox] for more details.
+
 :::
 
 ### Standalone
@@ -69,7 +71,9 @@ soroban config identity generate alice
 ```
 
 :::tip Test-only Identities
+
 It's a good practice to never use the same keys for testing and development that you use do for the public Stellar network. Generate new keys for testing and development and avoid ever using them for other purposes.
+
 :::
 
 Finally, fund your new account on the local sandbox environment by making a request to the local Friendbot:
@@ -79,7 +83,9 @@ curl "http://localhost:8000/friendbot?addr=$(soroban config identity address ali
 ```
 
 :::tip Command Expansion `$(...)`
+
 This uses [command expansion](https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html), which only works with bash-compatible shells. If you are using Windows or some other shell, you will need to copy the output of `soroban config…` and paste it into the `curl` command, or figure out how command expansion works in your shell.
+
 :::
 
 Now that you have a configured network and a funded identity, you can use these within other Soroban CLI commands. For example, deploying a contract:
@@ -250,7 +256,9 @@ helm template my-rpc stellar/soroban-rpc
 If using Kubernetes is not an option, this is the preferred way to deploy your own RPC instance.
 
 :::caution
+
 Although we have a [Quickstart Image](https://github.com/stellar/quickstart), it's for local development and testing only. It is not suitable for production-grade deployments.
+
 :::
 
 Here's how to run the [soroban-rpc docker image](https://hub.docker.com/r/stellar/soroban-rpc):
@@ -536,7 +544,9 @@ curl "https://friendbot.stellar.org/?addr=$(soroban config identity address alic
 See the tip above about command expansion (that's the note about `$(...)`) if you're not using a bash-based shell.
 
 :::caution
+
 When interacting with the network in production you should run your own soroban-rpc or use a third party infrastructure provider.
+
 :::
 
 ## Verify the RPC Instance


### PR DESCRIPTION
This PR updates the [RPC Usage](https://soroban.stellar.org/docs/reference/rpc) page to contain information in our [Soroban RPC Runbook](https://docs.google.com/document/d/1SIbrFWFgju5RAsi6stDyEtgTa78VEt8f3HhqCLoySx4/edit) for infrastructure providers.

Specifically:
- Caution that our Quickstart image is only for development purposes and should not be used in productoin
- Add instructions for deploying using our [soroban-rpc docker image](https://hub.docker.com/r/stellar/soroban-rpc)
- Add instructions for configuring your deployment from CLI and using a TOML configuration file
- Add instructions for building Soroban RPC from source
- Add instructions for verifying your Soroban RPC instance is healthy
- Add instructions for monitoring your Soroban RPC instance
- Add recommended hardware requirements based on [load tests](https://docs.google.com/document/d/1AKOTsH5XHJtOaulq1BLgTVCj4R9gkh1u0r5iDq_Gvxg/edit#heading=h.45du39dkhw62)