### PR TITLE
Update WASM retrieval tutorial JavaScript code

### DIFF
--- a/api/methods/getLedgerEntries.mdx
+++ b/api/methods/getLedgerEntries.mdx
@@ -214,14 +214,14 @@ print(
 ##### JavaScript
 
 ```javascript
-const { xdr } = require("soroban-client")
+const { Address, xdr } = require("soroban-client");
+
 function getLedgerKeyContractCode(contractId) {
   let ledgerKey = xdr.LedgerKey.contractData(
     new xdr.LedgerKeyContractData({
-      contract: xdr.ScAddress.scAddressTypeContract(contractId),
+      contract: new Address(contractId).toScAddress(),
       key: new xdr.ScVal.scvLedgerKeyContractInstance(),
-      durability: xdr.ContractDataDurability.persistent(),
-      bodyType: xdr.ContractEntryBodyType.dataEntry(),
+      durability: xdr.ContractDataDurability.persistent()
     })
   );
 
@@ -230,7 +230,7 @@ function getLedgerKeyContractCode(contractId) {
 
 console.log(
   getLedgerKeyContractCode(
-    "af9a2527e3b3b5571d63b0246ba32b7d31a5323766df7c60dfc0b3e3ba6fdf23"
+    "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
   )
 )
 // OUTPUT: AAAABq+aJSfjs7VXHWOwJGujK30xpTI3Zt98YN/As+O6b98jAAAAFA==
@@ -304,30 +304,19 @@ print(
 ##### JavaScript
 
 ```javascript
-const { xdr } = require("soroban-client")
+const { xdr } = require("soroban-client");
 
 function getLedgerKeyWasmId(contractCodeLedgerEntryData) {
-
-  let entry = xdr.LedgerEntryData.fromXDR(
+  const entry = xdr.LedgerEntryData.fromXDR(
     contractCodeLedgerEntryData,
     "base64"
   );
 
-  let instance = new xdr.ScContractInstance({
-    executable: entry.contractData()
-      .body()
-      .value()
-      .val()
-  });
+  const instance = entry.contractData().val().instance();
 
   let ledgerKey = xdr.LedgerKey.contractCode(
     new xdr.LedgerKeyContractCode({
-      hash: xdr.ContractExecutable.contractExecutableWasm(instance.executable())
-        .wasmHash()
-        .instance()
-        .executable()
-        .wasmHash(),
-      bodyType: xdr.ContractEntryBodyType.dataEntry()
+      hash: instance.wasmHash()
     })
   );
 


### PR DESCRIPTION
I had to derive this bit when helping someone in https://github.com/stellar/js-soroban-client/issues/166 and realized that there was some unnecessary verbosity in this code. To summarize:

* `bodyType` isn't a thing anymore
* hex contract IDs aren't a thing anymore
* the `ScContractInstance` can be parsed out of the fetched `LedgerEntryData` directly
* the `wasmHash` is part of the instance, no need to recreate it