### PR TITLE
Upgrade `getLedgerEntries` examples to latest pre-stable releases of the SDKs

### DIFF
--- a/api/methods/getLedgerEntries.mdx
+++ b/api/methods/getLedgerEntries.mdx
@@ -42,10 +42,10 @@ The example above is querying a deployment of the [`increment` example contract]
 
 :::note
 
-If you are using the Python `stellar_sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
+If you are using the [Python](https://stellar-sdk.readthedocs.io/en/9.0.0-beta0/) `stellar_sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
 
 ```bash
-pip install stellar-sdk==9.0.0-beta0
+pip install --upgrade --pre stellar-sdk
 ```
 
 :::
@@ -75,7 +75,7 @@ print(
 
 #### JavaScript
 
-If you are using the JavaScript `stellar-sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
+If you are using the [JavaScript](https://stellar.github.io/js-stellar-sdk/) `stellar-sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
 
 ```bash
 yarn add stellar-sdk@beta

--- a/api/methods/getLedgerEntries.mdx
+++ b/api/methods/getLedgerEntries.mdx
@@ -42,80 +42,84 @@ The example above is querying a deployment of the [`increment` example contract]
 
 :::note
 
-If you are using the Python `stellar_sdk` to generate these keys, you will need to install the latest version of the `soroban` branch of the SDK. This can be done like so:
+If you are using the Python `stellar_sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
 
 ```bash
-pip install git+https://github.com/StellarCN/py-stellar-base.git@soroban
+pip install stellar-sdk==9.0.0-beta0
 ```
 
 :::
 
 ```python
 from stellar_sdk import xdr
-from stellar_sdk.soroban import types as soroban_types
+from stellar_sdk.strkey  import StrKey
+from stellar_sdk.soroban import Symbol
 
 def get_ledger_key_symbol(contract_id: str, symbol_text: str) -> str:
-    ledger_key = xdr.LedgerKey(
-        type=xdr.LedgerEntryType.CONTRACT_DATA,
-        contract_data=xdr.LedgerKeyContractData(
-            contract_id=xdr.hash.Hash(bytes.fromhex(contract_id)),
-            key=soroban_types.Symbol(symbol_text).to_xdr_sc_val(),
-        ),
-    )
-    return ledger_key.to_xdr()
+  ledger_key = xdr.LedgerKey(
+    type=xdr.LedgerEntryType.CONTRACT_DATA,
+    contract_data=xdr.LedgerKeyContractData(
+      contract_id=xdr.hash.Hash(StrKey.decode_contract(contract_id)),
+      key=Symbol(symbol_text).to_xdr_sc_val(),
+    ),
+  )
+  return ledger_key.to_xdr()
 
 print(
-    get_ledger_key_symbol(
-        "58b53604fda60524fa7097fca030a6e840c4a84dccf7a4fe909790245e31a86f", "COUNTER"
-    )
+  get_ledger_key_symbol(
+    "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
+    "COUNTER"
+  )
 )
 ```
 
 #### JavaScript
 
+If you are using the JavaScript `stellar-sdk` to generate these keys, you will need to install the latest pre-release version of the SDK. This can be done like so:
+
+```bash
+yarn add stellar-sdk@beta
+```
+
 ```js
-const SorobanClient = require('soroban-client')
-const xdr = SorobanClient.xdr
+import { xdr, StrKey } from 'stellar-sdk';
 
 const getLedgerKeySymbol = (contractId, symbolText) => {
   const ledgerKey = xdr.LedgerKey.contractData(
     new xdr.LedgerKeyContractData({
-      contractId: Buffer.from(contractId, 'hex'),
+      contractId: StrKey.decodeContract(contractId),
       key: xdr.ScVal.scvSymbol(symbolText)
     })
+  );
+  return ledgerKey.toXDR('base64');
+};
+
+console.log(
+  getLedgerKeySymbol(
+    'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE',
+    'COUNTER'
   )
-  return ledgerKey.toXDR('base64')
-}
-console.log(getLedgerKeySymbol(
-  '58b53604fda60524fa7097fca030a6e840c4a84dccf7a4fe909790245e31a86f',
-  'COUNTER'
-))
+);
 ```
 
 ### Requesting an Account
 
 :::note
 
-This functionality is included in the js [soroban-client](https://www.npmjs.com/package/soroban-client) package as `Server.getAccount(address)`.
+This functionality is included in the JavaScript [stellar-sdk](https://www.npmjs.com/package/stellar-sdk) package as `SorobanRpc.Server.getAccount(address)`.
 
 :::
 
 Accounts are stored as ledger entries, so we can use this method to look up an account along with it's current sequence number.
 
 ```js
-const SorobanClient = require('soroban-client')
-const xdr = SorobanClient.xdr
+import { xdr, Keypair, StrKey } from 'stellar-sdk'
 
 const getLedgerKeyAccount = (address) => {
-  // We can use the `StrKey` library here to decode the address into the public
-  // key.
-  const publicKey = SorobanClient.StrKey.decodeEd25519PublicKey(address);
-
+  const publicKey = StrKey.decodeEd25519PublicKey(address)
   const ledgerKey = xdr.LedgerKey.account(
     new xdr.LedgerKeyAccount({
-      accountId: xdr.PublicKey.publicKeyTypeEd25519(
-        publicKey
-      ),
+      accountId: Keypair.fromPublicKey(publicKey).xdrPublicKey(),
     })
   )
   return ledgerKey.toXDR('base64')
@@ -190,23 +194,24 @@ When you deploy a contract, first the code is "installed" (i.e. it is uploaded o
 
 ```python
 from stellar_sdk import xdr
+from stellar_sdk.strkey import StrKey
 
 def get_ledger_key_contract_code(contract_id: str) -> str:
-    ledger_key = xdr.LedgerKey(
-        type=xdr.LedgerEntryType.CONTRACT_DATA,
-        contract_data=xdr.LedgerKeyContractData(
-            contract_id=xdr.Hash(bytes.fromhex(contract_id)),
-            key=xdr.SCVal(
-                type=xdr.SCValType.SCV_LEDGER_KEY_CONTRACT_EXECUTABLE,
-            ),
-        ),
-    )
-    return ledger_key.to_xdr()
+  ledger_key = xdr.LedgerKey(
+    type=xdr.LedgerEntryType.CONTRACT_DATA,
+    contract_data=xdr.LedgerKeyContractData(
+      contract_id=xdr.Hash(StrKey.decodeContract(contract_id)),
+      key=xdr.SCVal(
+        type=xdr.SCValType.SCV_LEDGER_KEY_CONTRACT_EXECUTABLE,
+      ),
+    ),
+  )
+  return ledger_key.to_xdr()
 
 print(
-    get_ledger_key_contract_code(
-        "af9a2527e3b3b5571d63b0246ba32b7d31a5323766df7c60dfc0b3e3ba6fdf23"
-    )
+  get_ledger_key_contract_code(
+    "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
+  )
 )
 # OUTPUT: AAAABq+aJSfjs7VXHWOwJGujK30xpTI3Zt98YN/As+O6b98jAAAAFA==
 ```
@@ -214,18 +219,11 @@ print(
 ##### JavaScript
 
 ```javascript
-const { Address, xdr } = require("soroban-client");
+import { Address, xdr } from 'stellar-sdk';
 
 function getLedgerKeyContractCode(contractId) {
-  let ledgerKey = xdr.LedgerKey.contractData(
-    new xdr.LedgerKeyContractData({
-      contract: new Address(contractId).toScAddress(),
-      key: new xdr.ScVal.scvLedgerKeyContractInstance(),
-      durability: xdr.ContractDataDurability.persistent()
-    })
-  );
-
-  return ledgerKey.toXDR('base64');
+  const [ _, instance ] = new ContractId(contractId).getFootprint();
+  return instance.toXDR('base64');
 }
 
 console.log(


### PR DESCRIPTION
A shortlist of the changes:
 * no need to use the `git` version for Python
 * use `stellar-sdk` over the now-deprecated `soroban-client`
 * use strkeys over hex IDs
 * use misc. other existing abstractions over hard-coding XDR stuff

cc @overcat for sanity-checking the Python stuff