### PR TITLE
docs: change sitewide wording from "preview release" to "release candidate"

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,19 +7,19 @@ Soroban is a smart contracts platform designed to be sensible, built-to-scale, b
 
 :::caution
 
-Soroban is a preview release. Breaking changes may occur.
+Soroban is currently a release candidate. While some changes may still occur before Mainnet launch, it can be considered relatively stable.
 
 :::
 
 While it works well with Stellar, a blockchain that shares its values of scale and sensibility, it doesn't depend on or require Stellar at all, and can be used by any transaction processor, including other blockchains, L2s, and permissioned ledgers.
 
-Currently, Soroban is a preview release that includes initial versions of the smart contracts environment, a Rust SDK, A CLI, and an RPC server. Developers can write and test contracts on their local machine or deploy them to Testnet.
+Currently, Soroban is a release candidate that includes versions of the smart contracts environment, a Rust SDK, A CLI, and an RPC server. Developers can write and test contracts on their local machine or deploy them to Testnet.
 
-## What "preview release" means
+## What "release candidate" means
 
-We’re releasing this very early version of Soroban because we believe it’s important to share the development process, and we want Stellar ecosystem developers and smart contract developers from other ecosystems to have a chance to experiment and provide feedback.
+We've been releasing very early versions of Soroban since the earliest days of its existence. We have moved on from having "preview releases," and the current state of Soroban is now a feature-complete _release candidate_. Development is still ongoing, but you can expect the current version of Soroban to be pretty close to what is officially released into production.
 
-Please test it out, see what you can do, and let us know what you think. Keep in mind a lot will change between now and the production release, so expect your code to break, and prepare for updates to shift things. Experiment, but don't build to last just yet.
+We still believe it's important to share the development process, and we want Stellar ecosystem developers and smart contract developers from other ecosystems to continue experimenting and are listening for feedback. Please keep testing it out, see what you can do, and let us know what you think. Keep in mind some changes may still occur between now and the production release, so your code may break, and further updates may cause some things to shift. Experiment, but don't build to last just yet.
 
 ## How to leave feedback
 

--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -4,17 +4,15 @@ title: Releases
 description: Soroban software releases and changelogs.
 ---
 
-The following Soroban releases are preview releases.
-
-We’re releasing early versions of Soroban because we believe it’s important to share the development process, and we want Stellar ecosystem developers and smart contract developers from other ecosystems to have a chance to experiment and provide feedback.
+We're releasing early versions of Soroban because we believe it's important to share the development process, and we want Stellar ecosystem developers and smart contract developers from other ecosystems to have a chance to experiment and provide feedback.
 
 :::caution
 
-Preview releases are software releases that are also released to the [Testnet] test network. Software releases may occur between Testnet releases. If you're interacting with Testnet the recommended software versions to use in development are below. Releases to Testnet may include network resets and network passphrase changes.
+Release candidates are software releases that are also released to the [Testnet] test network. Software releases may occur between Testnet releases. If you're interacting with Testnet, the recommended software versions to use in development are provided below. Releases to Testnet may include network resets and network passphrase changes.
 
 :::
 
-[Testnet]: testnet
+[Testnet]: testnet.mdx
 
 ## Preview 11 (September 11, 2023): Testnet and Futurenet Edition
 
@@ -44,7 +42,9 @@ Preview releases are software releases that are also released to the [Testnet] t
 | Testnet Network Passphrase   | `Test SDF Network ; September 2015`                                                                                                |
 
 :::note
+
 The Soroban RPC version for Preview 11 is presently in Stellar's unstable and testing apt repositories. Additionally, its Docker image release can be accessed at [docker.io/stellar/soroban-rpc:20.0.0-rc3-39](https://hub.docker.com/layers/stellar/soroban-rpc/20.0.0-rc3-39/images/sha256-227170869bca74998e1b6cc1e07deb3aca8d03e36154b3da700d6669e19d485b?context=explore).
+
 :::
 
 ### Changelog


### PR DESCRIPTION
Changing the wording anywhere I can find it from things like "preview release" to things like "release candidate"

fixes #626 