### PR TITLE
Fix openrpc playground urls

### DIFF
--- a/api/json-rpc.mdx
+++ b/api/json-rpc.mdx
@@ -14,11 +14,12 @@ When XDR is passed as a parameter or returned, it is always a string encoded usi
 
 ## Open-RPC Specification
 
-Soroban-RPC provides an [OpenRPC] specification document that can be used to mock, build, and/or validate both server and client software implementations. This document is used to generate all of our [methods] documentation pages. You can view the full [specification document here](/openrpc.json). Additionally, you can experiment with this specificaiton document in the [OpenRPC Playground].
+Soroban-RPC provides an [OpenRPC] specification document that can be used to mock, build, and/or validate both server and client software implementations. This document is used to generate all of our [methods] documentation pages. You can view the full [specification document here]. Additionally, you can experiment with this specificaiton document in the [OpenRPC Playground].
 
 [JSON-RPC 2.0]: <https://www.jsonrpc.org/specification>
 [jsonrpc error object]: <https://www.jsonrpc.org/specification#error_object>
 [js-soroban-client]: <https://github.com/stellar/js-soroban-client>
 [OpenRPC]: <https://open-rpc.org/>
 [methods]: <./methods>
+[specification document here]: <https://raw.githubusercontent.com/stellar/soroban-docs/main/static/openrpc.json>
 [OpenRPC Playground]: <https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/stellar/soroban-docs/main/static/openrpc.json>

--- a/api/json-rpc.mdx
+++ b/api/json-rpc.mdx
@@ -21,4 +21,4 @@ Soroban-RPC provides an [OpenRPC] specification document that can be used to moc
 [js-soroban-client]: <https://github.com/stellar/js-soroban-client>
 [OpenRPC]: <https://open-rpc.org/>
 [methods]: <./methods>
-[OpenRPC Playground]: <https://playground.open-rpc.org/?schemaUrl=https://soroban.stellar.org/openrpc.json>
+[OpenRPC Playground]: <https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/stellar/soroban-docs/main/static/openrpc.json>


### PR DESCRIPTION
The playground isn't working with the `/openrpc.json` file in this site, so I'm changing it to the github URL. Also changing the direct link to the github url, since docusaurus is generating some weird filename addition on the static asset.