### PR TITLE
Remove step adding target dir to gitignore

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -367,12 +367,6 @@ Go ahead and initialize `hello-soroban` as a git repository:
 git init
 ```
 
-You'll need a `.gitignore` to tell git to ignore the `target` directory:
-
-```bash
-echo target >> .gitignore
-```
-
 You should also ignore the `.soroban` directory:
 
 ```bash


### PR DESCRIPTION
### What
Remove step in tutorial adding target dir to gitignore.

### Why
The tutorial gets the user to run `cargo new` at the beginning, that creates a .gitignore file that already contains the target. So if they run the command as given they'll end up with target in the gitignore twice.