### PR TITLE
synchronize api example tabs across pages

### DIFF
--- a/patches/@metamask+open-rpc-docs-react+0.1.2.patch
+++ b/patches/@metamask+open-rpc-docs-react+0.1.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@metamask/open-rpc-docs-react/dist/ExamplePairing/ExamplePairing.js b/node_modules/@metamask/open-rpc-docs-react/dist/ExamplePairing/ExamplePairing.js
-index 354ce73..e113732 100644
+index 354ce73..5e07a7f 100644
 --- a/node_modules/@metamask/open-rpc-docs-react/dist/ExamplePairing/ExamplePairing.js
 +++ b/node_modules/@metamask/open-rpc-docs-react/dist/ExamplePairing/ExamplePairing.js
 @@ -45,10 +45,37 @@ class ExamplePairing extends react_1.Component {
@@ -47,7 +47,7 @@ index 354ce73..e113732 100644
                      react_1.default.createElement("div", null,
 -                        components && components.CodeBlock && react_1.default.createElement(components.CodeBlock, { className: "language-js" }, jsCode),
 +                        components && components.CodeBlock && components.Tabs && components.TabItem &&
-+                            react_1.default.createElement(components.Tabs, null,
++                            react_1.default.createElement(components.Tabs, { groupId: "rpc-examples" },
 +                                react_1.default.createElement(components.TabItem, { value: "curl", label: "cURL" },
 +                                    react_1.default.createElement(components.CodeBlock, { className: "language-bash" }, curlCode)),
 +                                react_1.default.createElement(components.TabItem, { value: "js", label: "JavaScript" },


### PR DESCRIPTION
The examples in the API pages don't currently sync from one page to the next (i.e., every page always defaults to the `curl` tab). This patch synchronizes them so you don't have to keep clicking the tabs as you navigate from one page to another.