### PR TITLE
Remove git init from hello world steps

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -361,13 +361,9 @@ Building optimized contracts is only necessary when deploying to a network with 
 
 Before we go on to deploying the contract to Testnet in the next section, this is a great time to commit your code to version control. Even if you don't share your project with others, this will make it easier for you to see and understand your own changes throughout the rest of the tutorial.
 
-Go ahead and initialize `hello-soroban` as a git repository:
+Cargo will have already setup the `hello-soroban` directory as a git repository.
 
-```bash
-git init
-```
-
-You should also ignore the `.soroban` directory:
+You should ignore the `.soroban` directory as it contains cached information about your local development and use of the soroban-cli:
 
 ```bash
 echo .soroban >> .gitignore


### PR DESCRIPTION
### What
Remove git init from hello world steps.

### Why
Cargo sets up a git repo already. This should be unnecessary.