### PR TITLE
Update soroban-sdk to v20.0.0-rc2.2

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -64,10 +64,10 @@ The `soroban-sdk` is in early development. Report issues [here](https://github.c
 
 ```toml
 [dependencies]
-soroban-sdk = "20.0.0-rc2"
+soroban-sdk = "20.0.0-rc2.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
@@ -129,10 +129,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc2"
+soroban-sdk = "20.0.0-rc2.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -86,7 +86,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "20.0.0-rc2"
+soroban-sdk = "20.0.0-rc2.2"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What
Update soroban-sdk to v20.0.0-rc2.2.

### Why
Soroban-sdk v20.0.0-rc2.2 was released because, when stellar-xdr v20.0.0 was released, v20.0.0-rc2 stopped building. Soroban-sdk v20.0.0-rc2 is loosely dependent on a version of stellar-xdr v20.0.0 and due to limitations in how cargo resolves pre-release versions it auto selects the stable v20.0.0 release even though the soroban-sdk requests v20.0.0-rc2.