### PR TITLE
docs: change Rust dependencies to specify exact prerelease version

### DIFF
--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -285,7 +285,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils"] }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/docs/basic-tutorials/alloc.mdx
+++ b/docs/basic-tutorials/alloc.mdx
@@ -62,10 +62,10 @@ This example depends on the `alloc` feature in `soroban-sdk`. To include it, add
 
 ```rust title="alloc/Cargo.toml"
 [dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["alloc"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["alloc"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils", "alloc"] }
 ```
 
 ## Code

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -255,11 +255,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "20.0.0-rc2" }
+soroban-sdk = { version = "=20.0.0-rc2.2" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -578,7 +578,7 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "20.0.0-rc2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -64,10 +64,10 @@ The `soroban-sdk` is in early development. Report issues [here](https://github.c
 
 ```toml
 [dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "=20.0.0-rc2.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
@@ -129,10 +129,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "=20.0.0-rc2.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
+soroban-sdk = { version = "=20.0.0-rc2.2", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -86,7 +86,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "=20.0.0-rc2.2"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
This changes every occurrence of the soroban-sdk to specify exactly that it should use version `=20.0.0-rc2.2` to avoid conflicts with current Testnet software.