### PR TITLE
remove rc2 references

### DIFF
--- a/docs/advanced-tutorials/fuzzing.mdx
+++ b/docs/advanced-tutorials/fuzzing.mdx
@@ -285,7 +285,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/docs/basic-tutorials/alloc.mdx
+++ b/docs/basic-tutorials/alloc.mdx
@@ -62,10 +62,10 @@ This example depends on the `alloc` feature in `soroban-sdk`. To include it, add
 
 ```rust title="alloc/Cargo.toml"
 [dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["alloc"] }
+soroban-sdk = { version = "20.0.0", features = ["alloc"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils", "alloc"] }
 ```
 
 ## Code

--- a/docs/basic-tutorials/upgrading-contracts.mdx
+++ b/docs/basic-tutorials/upgrading-contracts.mdx
@@ -78,7 +78,7 @@ pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
 
 The `update_current_contract_wasm` host function will also emit a `SYSTEM` contract [event] that contains the old and new wasm reference, allowing downstream users to be notified when a contract they use is updated. The event structure will have `topics = ["executable_update", old_executable: ContractExecutable, old_executable: ContractExecutable]` and `data = []`.
 
-[here]: https://docs.rs/soroban-sdk/20.0.0-rc2/soroban_sdk/struct.Env.html#method.update_current_contract_wasm
+[here]: https://docs.rs/soroban-sdk/20.0.0/soroban_sdk/struct.Env.html#method.update_current_contract_wasm
 [event]: ../fundamentals-and-concepts/events.mdx#event-types
 
 ## Tests

--- a/docs/basic-tutorials/wasm-metadata.mdx
+++ b/docs/basic-tutorials/wasm-metadata.mdx
@@ -38,5 +38,5 @@ contractmeta!(
 pub trait LiquidityPoolTrait {...
 ```
 
-[contractmeta!]: https://docs.rs/soroban-sdk/20.0.0-rc2/soroban_sdk/macro.contractmeta.html
+[contractmeta!]: https://docs.rs/soroban-sdk/20.0.0/soroban_sdk/macro.contractmeta.html
 [liquidity pool example]: https://github.com/stellar/soroban-examples/blob/v20.0.0/liquidity_pool/src/lib.rs#L152-L155

--- a/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/smart-contract-deployment.mdx
@@ -255,11 +255,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "20.0.0-rc2" }
+soroban-sdk = { version = "20.0.0" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
+++ b/docs/fundamentals-and-concepts/migrating-from-evm/solidity-and-rust-basics.mdx
@@ -575,10 +575,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc2"
+soroban-sdk = "20.0.0"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -58,10 +58,10 @@ Add the following sections to the `Cargo.toml` to import the `soroban-sdk`, and 
 
 ```toml
 [dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "20.0.0"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]
@@ -123,10 +123,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "20.0.0"
 
 [dev_dependencies]
-soroban-sdk = { version = "20.0.0-rc2.2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/docs/getting-started/storing-data.mdx
+++ b/docs/getting-started/storing-data.mdx
@@ -86,7 +86,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "20.0.0-rc2.2"
+soroban-sdk = "20.0.0"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
This PR replaces references to the "rc" version with the stable "v20" version in the SDK 