### PR TITLE
Update quickstart version to testing

### DIFF
--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -29,7 +29,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Soroban RPC                  | `v20.0.2`                                                                                                                          |
 | Stellar Horizon              | `v2.27.0`                                                                                                                          |
 | Stellar Friendbot            | `TBD`                                                                                                                              |
-| Stellar Quickstart           | `docker.io/stellar/quickstart:soroban-dev@sha256:bc9aa3653b1f3550eb940c8626d525f58967b73458e51024dce8588204698ddf`                 |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:972b3d934d133d95d2dc927ff8bc51d72a28145a65de063c1780378f183b80dc`                     |
 | Stellar JS Stellar Base      | [`v10.0.0`](https://github.com/stellar/js-stellar-base/releases/tag/v10.0.0)                                                       |
 | Stellar JS Stellar SDK       | [`v11.0.1`](https://github.com/stellar/js-stellar-sdk/releases/tag/v11.0.1)                                                        |
 | Stellar JS Soroban Client    | [`v1.0.0`](https://github.com/stellar/js-soroban-client/releases/tag/v1.0.0) (deprecated, prefer the Stellar SDK)                  |

--- a/docs/reference/releases.mdx
+++ b/docs/reference/releases.mdx
@@ -29,7 +29,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Soroban RPC                  | `v20.0.2`                                                                                                                          |
 | Stellar Horizon              | `v2.27.0`                                                                                                                          |
 | Stellar Friendbot            | `TBD`                                                                                                                              |
-| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:972b3d934d133d95d2dc927ff8bc51d72a28145a65de063c1780378f183b80dc`                     |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:testing@sha256:3c7947f65db493f2ab8ca639753130ba4916c57d000d4a1f01ec530e3423853b`                     |
 | Stellar JS Stellar Base      | [`v10.0.0`](https://github.com/stellar/js-stellar-base/releases/tag/v10.0.0)                                                       |
 | Stellar JS Stellar SDK       | [`v11.0.1`](https://github.com/stellar/js-stellar-sdk/releases/tag/v11.0.1)                                                        |
 | Stellar JS Soroban Client    | [`v1.0.0`](https://github.com/stellar/js-soroban-client/releases/tag/v1.0.0) (deprecated, prefer the Stellar SDK)                  |


### PR DESCRIPTION
The soroban-dev image is using an outdated version of soroban-rpc, and this should point to testing anyways now that Soroban is on testnet.