### PR TITLE
doc: update soroban-cli version

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -74,7 +74,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```bash
-cargo install --locked --version 20.0.2 soroban-cli
+cargo install --locked --version 20.1.0 soroban-cli
 ```
 
 :::info


### PR DESCRIPTION
The version 20.0.2 used on the docs does not let the developer deploy the contract made on the [Getting Started](https://soroban.stellar.org/docs/getting-started/deploy-to-testnet#deploy). It throw this error:
`error: jsonrpc error: ErrorObject { code: InvalidParams, message: "invalid parameters", data: Some(RawValue("[-32602] got 1 parameters, want 2")) }`

The version 20.1.0 fixed this issue.