### PR TITLE
update soroban-cli to v20.1.1

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -338,7 +338,7 @@ The `.wasm` file contains the logic of the contract, as well as the contract's [
 
 Use `soroban contract optimize` to further minimize the size of the `.wasm`. First, re-install soroban-cli with the `opt` feature:
 
-    cargo install --locked --version 20.1.0 soroban-cli --features opt
+    cargo install --locked soroban-cli --features opt
 
 Then build an optimized `.wasm` file:
 

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -74,7 +74,7 @@ contract will execute on network, however in a local sandbox.
 Install the Soroban CLI using `cargo install`.
 
 ```bash
-cargo install --locked --version 20.1.0 soroban-cli
+cargo install --locked soroban-cli
 ```
 
 :::info

--- a/docs/reference/soroban-cli.mdx
+++ b/docs/reference/soroban-cli.mdx
@@ -9,7 +9,7 @@ Soroban CLI is the command line interface to Soroban. It allows you to build, de
 Install Soroban CLI as explained in [Setup](../getting-started/setup).
 
 Auto-generated comprehensive reference documentation is available at:
-https://github.com/stellar/soroban-tools/blob/v20.1.0/docs/soroban-cli-full-docs.md
+https://github.com/stellar/soroban-tools/blob/v20.1.1/docs/soroban-cli-full-docs.md
 
 Subscribe to releases on the GitHub repository:
 https://github.com/stellar/soroban-tools


### PR DESCRIPTION
I noticed in the [cli readme](https://github.com/stellar/soroban-tools/blob/main/cmd/soroban-cli/README.md), the installation step doesn't specify a version. Now that we're in stable releases territory, is it preferable to omit the version number? Or, should we continue to specify it on install?