### PR TITLE
Fix description of enums supported by contract types

### DIFF
--- a/docs/soroban-internals/types/custom-types.mdx
+++ b/docs/soroban-internals/types/custom-types.mdx
@@ -146,4 +146,3 @@ When converted to XDR, the value becomes an `ScVal`, containing a `U32`.
 ```json
 { "u32": 1 }
 ```
-

--- a/docs/soroban-internals/types/custom-types.mdx
+++ b/docs/soroban-internals/types/custom-types.mdx
@@ -97,8 +97,7 @@ element vector, where the first element is the name of the enum variant as a
 string up to 32 characters in length, and the value is the value if the variant
 has one.
 
-Only unit variants and single value variants, like `A` and `B` below, are
-supported.
+Only unit variants and tuple variants, like `A` and `B` below, are supported.
 
 ```rust
 #[contracttype]
@@ -147,3 +146,4 @@ When converted to XDR, the value becomes an `ScVal`, containing a `U32`.
 ```json
 { "u32": 1 }
 ```
+


### PR DESCRIPTION
### What
Change definition of enum types supported by contract types to state that unit and tuple types are supported.

### Why
Some time ago someone (I think @brson?) added support for multiple value tuple-like enum variants. The docs still say that only single value tuple-like enum variants are supported.

Thanks to @FredericRezeau for pointing this out in https://github.com/stellar/soroban-examples/issues/295#issuecomment-1895000305.