### PR TITLE
Update maximum contract size limit in the `Getting Started` tutorial to `64kb`

### DIFF
--- a/docs/getting-started/hello-world.mdx
+++ b/docs/getting-started/hello-world.mdx
@@ -76,7 +76,7 @@ The `testutils` are automatically enabled inside [Rust unit tests] inside the sa
 
 ### Configure the `release` Profile
 
-Configuring the `release` profile to optimize the contract build is critical. Soroban contracts have a maximum size of 256KB. Rust programs, even small ones, without these configurations almost always exceed this size.
+Configuring the `release` profile to optimize the contract build is critical. Soroban contracts have a maximum size of 64KB. Rust programs, even small ones, without these configurations almost always exceed this size.
 
 Add the following to your `Cargo.toml` and use the `release` profile when building.
 


### PR DESCRIPTION
See Discord discussion [here](https://discord.com/channels/897514728459468821/966788672164855829/1198629347528020069)