### PR TITLE
add redirect for the SDC catalog

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -21,6 +21,7 @@ rewrite "^/docs/SDKs/rust$" "/docs/reference/sdks/write-contracts" permanent;
 rewrite "^/docs/getting-started/connect-freighter-wallet$" "/docs/reference/freighter" permanent;
 rewrite "^/docs/common-interfaces/token$" "/docs/tokens/token-interface" permanent;
 rewrite "^/docs/how-to-guides/tokens$" "/docs/tutorials/tokens" permanent;
+rewrite "^/dapps/category/challenges$" "/dashboard" permanent;
 # BEGIN re-structure redirects
 rewrite "^/sorobanathon" "/" permanent;
 rewrite "^/docs/reference/interfaces/token-interface" "/docs/tokens/token-interface" permanent;


### PR DESCRIPTION
Adds a redirect to the Soroban Dapps Challenge catalog to the dashboard instead of the old challenges catalog page.