### PR TITLE
fix redirect regexes to avoid duplicate `/` slash

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -39,5 +39,5 @@ rewrite "^/docs/fundamentals-and-concepts/(built-in-types|custom-types|fully-typ
 rewrite "^/docs/fundamentals-and-concepts/invoking-contracts-with-transactions$" "/docs/soroban-internals/contract-interactions/stellar-transaction" permanent;
 rewrite "^/docs/soroban-internals/contract-interactions/stellar-transactions$" "/docs/soroban-internals/contract-interactions/stellar-transaction" permanent;
 rewrite "^/docs/fundamentals-and-concepts/interacting-with-contracts$" "/docs/soroban-internals/contract-interactions" permanent;
-rewrite "^/docs/(basic|advanced)-tutorials(/.*)$" "/docs/tutorials/$2" permanent;
-rewrite "^/docs/fundamentals-and-concepts(/.*)$" "/docs/soroban-internals/$1" permanent;
+rewrite "^/docs/(basic|advanced)-tutorials(/.*)$" "/docs/tutorials$2" permanent;
+rewrite "^/docs/fundamentals-and-concepts(/.*)$" "/docs/soroban-internals$1" permanent;


### PR DESCRIPTION
regular expressions for `/docs/fundamentals-and-concepts/whatever` as well as `/docs/basic-tutorials/whatever` are currently redirecting with two `/` slash characters