### PR TITLE
docs: Link to soroban-rpc Repo for Soroban RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ basics:
 [Docusaurus]: https://docusaurus.io
 [MDX]: https://mdxjs.com
 [yarn]: https://yarnpkg.com/
-[Soroban RPC]: https://github.com/stellar.org/soroban-tools/cmd/soroban-rpc
+[Soroban RPC]: https://github.com/stellar.org/soroban-rpc/cmd/soroban-rpc
 [OpenRPC specification]: https://github.com/stellar/soroban-docs/blob/main/static/openrpc.json
 [create an issue]: https://github.com/stellar/soroban-docs/issues
 [Dapps Challenge]: https://soroban.stellar.org/dapps

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -27,7 +27,7 @@ The Quickstart image with the RPC service can run on a standard laptop with 8GB 
 - [Friendbot server] - HTTP API for creating and funding new accounts on test networks.
 
 [Stellar Core]: https://github.com/stellar/stellar-core
-[Soroban RPC]: https://github.com/stellar/soroban-tools/tree/main/cmd/soroban-rpc
+[Soroban RPC]: https://github.com/stellar/soroban-rpc/tree/main/cmd/soroban-rpc
 [Horizon server]: https://github.com/stellar/go/tree/master/services/horizon
 [Friendbot server]: https://github.com/stellar/go/tree/master/services/friendbot
 
@@ -515,7 +515,7 @@ Note that the above generated configuration contains the default values and you 
 
 ### Build From Source
 
-Instructions for building Soroban RPC from source can be found [here](https://github.com/stellar/soroban-tools/blob/main/cmd/soroban-rpc/README.md).
+Instructions for building Soroban RPC from source can be found [here](https://github.com/stellar/soroban-rpc/blob/main/cmd/soroban-rpc/README.md).
 
 ### Hardware Requirements
 


### PR DESCRIPTION
[Related to RPC/CLI repo split](https://github.com/stellar/soroban-tools/issues/1171)

This PR updates all RPC references from the `soroban-tools` repo to the new `soroban-rpc` repo