### PR TITLE
Reinstate the ordering of the example contracts.

### DIFF
--- a/docs/tutorials/README.mdx
+++ b/docs/tutorials/README.mdx
@@ -7,6 +7,8 @@ import DocCardList from "@theme/DocCardList";
 
 The Soroban team has put together a large collection of [example contracts] to demonstrate use of the Soroban smart contracts platform. For many of these example contracts, we've written an accompanying "tutorial" that will walk you through the example contracts and describe a bit more about their design. You can think of these "tutorials" as example contracts that end with a deployable smart contract. You can use the provided filters to find a relevant tutorial for your experience level.
 
+The tutorials listed below are provided in a sequential manner. The first listed example contracts create a solid foundation of concepts that will be required during the later examples. While you are absolutely free to choose, read, and use any of the example contracts you like, please keep in mind that the order you see is intentional.
+
 <DocCardList />
 
 [example contracts]: https://github.com/stellar/soroban-examples

--- a/docs/tutorials/TEMPLATE.mdx
+++ b/docs/tutorials/TEMPLATE.mdx
@@ -2,6 +2,7 @@
 title: Tutorial Template
 description: A description of the tutorial that is being written.
 draft: true
+sidebar_position: 1000
 sidebar_custom_props:
   tutorial:
     level: intermediate

--- a/docs/tutorials/alloc.mdx
+++ b/docs/tutorials/alloc.mdx
@@ -1,6 +1,7 @@
 ---
 title: Allocator
 description: Use the allocator feature to emulate heap memory in a smart contract.
+sidebar_position: 80
 sidebar_custom_props:
   tutorial:
     level: intermediate

--- a/docs/tutorials/atomic-multi-swap.mdx
+++ b/docs/tutorials/atomic-multi-swap.mdx
@@ -1,6 +1,7 @@
 ---
 title: Batched Atomic Swaps
 description: Swap a token pair among groups of authorized users.
+sidebar_position: 100
 sidebar_custom_props:
   tutorial:
     level: advanced

--- a/docs/tutorials/atomic-swap.mdx
+++ b/docs/tutorials/atomic-swap.mdx
@@ -1,6 +1,7 @@
 ---
 title: Atomic Swap
 description: Swap tokens atomically between authorized users.
+sidebar_position: 90
 sidebar_custom_props:
   tutorial:
     level: advanced

--- a/docs/tutorials/auth.mdx
+++ b/docs/tutorials/auth.mdx
@@ -1,6 +1,7 @@
 ---
 title: Auth
 description: Implement authentication and authorization.
+sidebar_position: 50
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/cross-contract-call.mdx
+++ b/docs/tutorials/cross-contract-call.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cross Contract Calls
 description: Call a smart contract from another smart contract.
+sidebar_position: 60
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/custom-account.mdx
+++ b/docs/tutorials/custom-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: Custom Account
 description: Implement an account contract supporting multisig and custom authorization policies.
+sidebar_position: 150
 sidebar_custom_props:
   tutorial:
     level: advanced

--- a/docs/tutorials/custom-types.mdx
+++ b/docs/tutorials/custom-types.mdx
@@ -1,6 +1,7 @@
 ---
 title: Custom Types
 description: Define your own data structures in a smart contract.
+sidebar_position: 20
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/deployer.mdx
+++ b/docs/tutorials/deployer.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deployer
 description: Deploy and initialize a smart contract using another smart contract.
+sidebar_position: 70
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/errors.mdx
+++ b/docs/tutorials/errors.mdx
@@ -1,6 +1,7 @@
 ---
 title: Errors
 description: Define and generate errors in a smart contract.
+sidebar_position: 30
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/events.mdx
+++ b/docs/tutorials/events.mdx
@@ -1,6 +1,7 @@
 ---
 title: Events
 description: Publish events from a smart contract.
+sidebar_position: 10
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/fuzzing.mdx
+++ b/docs/tutorials/fuzzing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Fuzz Testing
 description: Increase confidence in a contract's correctness with fuzz testing.
+sidebar_position: 160
 sidebar_custom_props:
   tutorial:
     level: advanced

--- a/docs/tutorials/liquidity-pool.mdx
+++ b/docs/tutorials/liquidity-pool.mdx
@@ -1,6 +1,7 @@
 ---
 title: Liquidity Pool
 description: Write a constant-product liquidity pool contract.
+sidebar_position: 130
 sidebar_custom_props:
   tutorial:
     level: intermediate

--- a/docs/tutorials/logging.mdx
+++ b/docs/tutorials/logging.mdx
@@ -1,6 +1,7 @@
 ---
 title: Logging
 description: Debug a smart contract with logs.
+sidebar_position: 40
 sidebar_custom_props:
   tutorial:
     level: beginner

--- a/docs/tutorials/single-offer-sale.mdx
+++ b/docs/tutorials/single-offer-sale.mdx
@@ -1,6 +1,7 @@
 ---
 title: Single Offer Sale
 description: Make a standing offer to sell a token in exchange for another token.
+sidebar_position: 120
 sidebar_custom_props:
   tutorial:
     level: intermediate

--- a/docs/tutorials/timelock.mdx
+++ b/docs/tutorials/timelock.mdx
@@ -1,6 +1,7 @@
 ---
 title: Timelock
 description: Lockup some token to be claimed by another user under set conditions.
+sidebar_position: 110
 sidebar_custom_props:
   tutorial:
     level: intermediate

--- a/docs/tutorials/tokens.mdx
+++ b/docs/tutorials/tokens.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tokens
 description: Write a CAP-46-6 compliant token contract.
+sidebar_position: 140
 sidebar_custom_props:
   tutorial:
     level: beginner


### PR DESCRIPTION
The ordering is intentional so as to give folks a basic understanding before moving on to more complex topics. I've re-created the order here that existed previously.

Closes #717 

@leighmcculloch Here's a first stab at this. I re-did the order in your screenshot, since the reorg also did away with the folders for `{basic,advanced}-tutorials`. The only one that wasn't there at that time was the Fuzzing example. That's tacked on at the end of the list for the time being, is there a better place to put it within the order? I was thinking maybe after `Allocator`? Is the note I added at the top of the Tutorials page enough to explain the idea, or should we do something else to communicate that there _is_ an intended order to these things?

Also, honest question: What are your thoughts on the way we have the tutorials listed now (As one list that's filter-able and searchable)? The main goal was to "un-clutter" the sidebar, and display them in a more convenient way. Is it useful? Is it harmful? I just want to make sure I'm not blinded by being "too close" to the feature and just assuming it's great lol