### PR TITLE
Fix case of parameter

### DIFF
--- a/api/pagination.mdx
+++ b/api/pagination.mdx
@@ -16,7 +16,7 @@ For example, calling a method with pagination parameter set:
 ```json
 {
   "jsonrpc": "2.0",
-  "Id": "1",
+  "id": "1",
   "method": "exampleMethod",
   "params": ["other", "arguments", { "cursor": "1234-1", "limit": 100 }]
 }


### PR DESCRIPTION
### What

Change the case of the `id` parameter from `Id` to `id`.

### Why

Looks like a typo. The `id` parameter is always lower case.