### PR TITLE
Refactor deprecated calls to `soroban config`

### DIFF
--- a/dapps/guides/initialization.mdx
+++ b/dapps/guides/initialization.mdx
@@ -142,18 +142,18 @@ esac
 
 
 echo Add the $NETWORK network to cli client
-soroban config network add \
+soroban network add \
   --rpc-url "$SOROBAN_RPC_URL" \
   --network-passphrase "$SOROBAN_NETWORK_PASSPHRASE" "$NETWORK"
 
-if !(soroban config identity ls | grep token-admin 2>&1 >/dev/null); then
+if !(soroban keys ls | grep token-admin 2>&1 >/dev/null); then
   echo Create the token-admin identity
-  soroban config identity generate token-admin
+  soroban keys generate token-admin
 fi
-TOKEN_ADMIN_SECRET="$(soroban config identity show token-admin)"
-TOKEN_ADMIN_ADDRESS="$(soroban config identity address token-admin)"
+TOKEN_ADMIN_SECRET="$(soroban keys show token-admin)"
+TOKEN_ADMIN_ADDRESS="$(soroban keys address token-admin)"
 
-# TODO: Remove this once we can use `soroban config identity` from webpack.
+# TODO: Remove this once we can use `soroban keys` from webpack.
 mkdir -p .soroban-example-dapp
 echo "$TOKEN_ADMIN_SECRET" > .soroban-example-dapp/token_admin_secret
 echo "$TOKEN_ADMIN_ADDRESS" > .soroban-example-dapp/token_admin_address
@@ -207,8 +207,8 @@ Here's a summary of what the `initialize.sh` script does:
 - Determines the Soroban RPC host URL depending on its execution environment (either inside the soroban-preview Docker container or locally)
 - Sets the Soroban RPC URL based on the previously determined host URL
 - Sets the Soroban network passphrase and Friendbot URL depending on the chosen network
-- Adds the network configuration to Soroban using `soroban config network add`
-- Generates a token-admin identity using `soroban config identity generate`
+- Adds the network configuration to Soroban using `soroban network add`
+- Generates a token-admin identity using `soroban keys generate`
 - Fetches the TOKEN_ADMIN_SECRET and TOKEN_ADMIN_ADDRESS from the newly generated identity
 - Saves the TOKEN_ADMIN_SECRET and TOKEN_ADMIN_ADDRESS in the .soroban directory
 - Funds the token-admin account using Friendbot

--- a/docs/getting-started/create-an-app.mdx
+++ b/docs/getting-started/create-an-app.mdx
@@ -428,7 +428,7 @@ Next, let's add a `setup` script that builds your contracts, then checks if the 
 ```json title="package.json"
   "scripts": {
     ...
-   "create_deployer": "soroban config identity generate alice && soroban config identity fund alice --network testnet",
+   "create_deployer": "soroban keys generate alice && soroban keys fund alice --network testnet",
    "deploy:hello": "soroban contract deploy --wasm target/wasm32-unknown-unknown/release/hello_soroban.wasm --source alice --network testnet > .soroban/hello-id",
    "deploy:incrementor": "soroban contract deploy --wasm target/wasm32-unknown-unknown/release/incrementor.wasm --source alice --network testnet > .soroban/incrementor-id;",
    "deploy": "npm run deploy:hello && npm run deploy:incrementor",

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -167,13 +167,13 @@ When you deploy a smart contract to a network, you need to specify an identity t
 Let's configure an identity called `alice`. You can use any name you want, but it might be nice to have some named identities that you can use for testing, such as [`alice`, `bob`, and `carol`](https://en.wikipedia.org/wiki/Alice_and_Bob).
 
 ```bash
-soroban config identity generate --global alice
+soroban keys generate --global alice
 ```
 
 You can see the public key of `alice` with:
 
 ```bash
-soroban config identity address alice
+soroban keys address alice
 ```
 
 Like the Network configs, the `--global` means that the identity gets stored in `~/.config/soroban/identity/alice.toml`. You can omit the `--global` flag to store the identity in your project's `.soroban/identity` folder instead.
@@ -183,7 +183,7 @@ All this did so far is generate a public/private keypair on your local machine. 
 To get `alice` some Testnet tokens, you'll need to use [Friendbot](https://developers.stellar.org/docs/fundamentals-and-concepts/testnet-and-pubnet#friendbot). All Stellar and Soroban test networks have a Friendbot that you can use to get some test tokens. The public Friendbot instance for Testnet lives at `https://friendbot.stellar.org`. Use it:
 
 ```bash
-curl "https://friendbot.stellar.org/?addr=$(soroban config identity address alice)"
+curl "https://friendbot.stellar.org/?addr=$(soroban keys address alice)"
 ```
 
 :::tip Command Expansion `$(…)`

--- a/docs/guides/conventions/upgrading-contracts.mdx
+++ b/docs/guides/conventions/upgrading-contracts.mdx
@@ -224,8 +224,8 @@ You also need to call the `init` method so the `admin` is set. This requires us
 to setup som identities.
 
 ```sh
-soroban config identity generate acc1 && \
-soroban config identity address acc1
+soroban keys generate acc1 && \
+soroban keys address acc1
 ```
 
 Example output:

--- a/docs/reference/rpc.mdx
+++ b/docs/reference/rpc.mdx
@@ -67,7 +67,7 @@ soroban config network add standalone \
 Then generate a unique identity (public/private keypair) to use with it:
 
 ```bash
-soroban config identity generate alice
+soroban keys generate alice
 ```
 
 :::tip Test-only Identities
@@ -79,7 +79,7 @@ It's a good practice to never use the same keys for testing and development that
 Finally, fund your new account on the local sandbox environment by making a request to the local Friendbot:
 
 ```bash
-curl "http://localhost:8000/friendbot?addr=$(soroban config identity address alice)"
+curl "http://localhost:8000/friendbot?addr=$(soroban keys address alice)"
 ```
 
 :::tip Command Expansion `$(...)`
@@ -140,7 +140,7 @@ Replace `testnet` in that command with the name of your choice if you want to le
 The `alice` identity suggested for your Standalone network will still work here, since it's just a public/private keypair, but you'll need to remember to fund it for the Testnet network:
 
 ```bash
-curl "https://friendbot.stellar.org/?addr=$(soroban config identity address alice)"
+curl "https://friendbot.stellar.org/?addr=$(soroban keys address alice)"
 ```
 
 Now you can replace `--network standalone` with `--network testnet` (or whatever you named it) in all your commands that need a network, like the `deploy` and `invoke` commands shown above.
@@ -171,7 +171,7 @@ Replace `futurenet` in that command with the name of your choice, if you want to
 The `alice` identity suggested for your Standalone and Testnet networks will still work here, since it's just a public/private keypair, but you'll need to remember to fund it for the Futurenet network:
 
 ```bash
-curl "https://friendbot-futurenet.stellar.org/?addr=$(soroban config identity address alice)"
+curl "https://friendbot-futurenet.stellar.org/?addr=$(soroban keys address alice)"
 ```
 
 Now you can replace `--network standalone` with `--network futurenet` (or whatever you named it) in all your commands that need a network, like the `deploy` and `invoke` commands shown above.
@@ -538,7 +538,7 @@ soroban config network add --global testnet \
 And fund your accounts/identities with the publicly hosted Friendbot:
 
 ```bash
-curl "https://friendbot.stellar.org/?addr=$(soroban config identity address alice)"
+curl "https://friendbot.stellar.org/?addr=$(soroban keys address alice)"
 ```
 
 See the tip above about command expansion (that's the note about `$(...)`) if you're not using a bash-based shell.

--- a/docs/tutorials/auth.mdx
+++ b/docs/tutorials/auth.mdx
@@ -327,10 +327,10 @@ But since we are dealing with authorization and signatures, we need to set up
 some identities to use for testing and get their public keys:
 
 ```sh
-soroban config identity generate acc1 && \
-soroban config identity generate acc2 && \
-soroban config identity address acc1 && \
-soroban config identity address acc2
+soroban keys generate acc1 && \
+soroban keys generate acc2 && \
+soroban keys address acc1 && \
+soroban keys address acc2
 ```
 
 Example output with two public keys of identities:


### PR DESCRIPTION
As noted on https://github.com/stellar/soroban-tools/blob/main/docs/soroban-cli-full-docs.md

> config — Deprecated, use soroban keys and soroban network instead

This PR addresses update all mentions of `soroban config` to the proper usage.