### PR TITLE
add redirect for the meeting notes url

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -42,3 +42,4 @@ rewrite "^/docs/soroban-internals/contract-interactions/stellar-transactions$" "
 rewrite "^/docs/fundamentals-and-concepts/interacting-with-contracts$" "/docs/soroban-internals/contract-interactions" permanent;
 rewrite "^/docs/(basic|advanced)-tutorials(/.*)$" "/docs/tutorials$2" permanent;
 rewrite "^/docs/fundamentals-and-concepts(/.*)$" "/docs/soroban-internals$1" permanent;
+rewrite "^/docs/notes" "/meetings" permanent;


### PR DESCRIPTION
We moved from having the meeting notes as a single markdown page at `/docs/notes` to utilizing Docusaurus' blog feature (#719), so here is a redirect for those URLs to be sent to `/meetings`