### PR TITLE
Add v20.2.0 release to `releases.mdx` 

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -14,6 +14,41 @@ Release candidates are software releases that are also released to the [Testnet]
 
 [Testnet]: reference/networks.mdx
 
+## Stable v20.2.0 (February 5, 2024)
+
+### Software
+
+| Software                     | Version                                                                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| XDR                          | [b96148cd4acc372cc9af17b909ffe4b12c43ecb6](https://github.com/stellar/stellar-xdr/commit/b96148cd4acc372cc9af17b909ffe4b12c43ecb6) |
+| Soroban Environment          | `v20.2.2`                                                                                                                          |
+| Soroban Interface Version    | `0`                                                                                                                                |
+| Stellar Core                 | `v20.2.0`                                                                                                                          |
+| Soroban Rust SDK             | `v20.3.0`                                                                                                                          |
+| Soroban CLI                  | `v20.3.0`                                                                                                                          |
+| Soroban RPC                  | `v20.3.1`                                                                                                                          |
+| Stellar Horizon              | `v2.27.0`                                                                                                                          |
+| Stellar Friendbot            | `TBD`                                                                                                                              |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:latest@sha256:8d6f6520ad3842042bfe4e271f8b2324ec2f128564487abedd3876cea83af4f1`                      |
+| Stellar JS Stellar Base      | [`v11.0.0`](https://github.com/stellar/js-stellar-base/releases/tag/v11.0.0)                                                       |
+| Stellar JS Stellar SDK       | [`v11.2.2`](https://github.com/stellar/js-stellar-sdk/releases/tag/v11.2.2)                                                        |
+| Freighter                    | `5.16.0`                                                                                                                           |
+| Laboratory                   | `v4.1.0`                                                                                                                           |
+| Soroban React Payment dapp   | `v3.0.0`                                                                                                                           |
+| Soroban Mint Token dapp      | `v3.0.0`                                                                                                                           |
+| Soroban Swap Token dapp      | `TBD`                                                                                                                              |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022`                                                                                           |
+| Testnet Network Passphrase   | `Test SDF Network ; September 2015`                                                                                                |
+
+### Changelog
+
+#### Soroban Rust SDK
+
+- Fix bug with Timepoint/Duration as parameters/returns
+- Add storage update fns
+- Export functions for creating Timepoint/Duration
+- Allow `&Env` in contract fns
+
 ## Stable v20.1.0 (January 11, 2024)
 
 ### Software

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -14,7 +14,7 @@ Release candidates are software releases that are also released to the [Testnet]
 
 [Testnet]: reference/networks.mdx
 
-## Stable v20.2.0 (February 5, 2024)
+## Protocol 20 (February 5, 2024): Mainnet Edition (Phase 0)
 
 ### Software
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -42,7 +42,79 @@ Release candidates are software releases that are also released to the [Testnet]
 
 ### Changelog
 
+#### XDR
+
+Run CI for the msrv and latest rust version
+Backfill changes to next for json rendering
+Bump XDR
+Bump version to 20.1.0
+
+#### Soroban Environment
+
+Allow small version-range wiggle room on curve25519-dalek to enable docs.rs nightly build
+Bump version to 20.2.2
+Enable publish of soroban-simulation crate
+Add a function to invoke host function 'end-to-end' in recording mode.
+Bug 1283 asset code rendering
+Use strkeys for contract IDs and addresses in diagnostic events.
+Turn off wasm_reference_types in Wasmi
+Prng tests
+Remove ConversionError from ScVal/Val conversions
+Tightening up metering in auth
+Bump XDR to 20.1
+Allow negative fee1 kb low
+Bump version to 20.2.0
+Cover various Symbol conversion code paths with various valid/invalid cases
+Run CI for the msrv and latest rust version
+Add protocol version method to invoke_contract
+Enable VM execution in a WASM environment by guarding time track behind time feature
+Add test for checking VM stack depth.
+Migrate preflight computations from soroban-rpc
+soroban-simulate: Misc fixes
+Add CI job to run cargo-semver-checks
+Tracing
+Add some basic test coverage for e2e_invoke.
+Add test vectors for ed25519 edge cases
+Trace should not emit diagnostic errors
+Bump wasmi to 0.31.1-soroban.20.0.1
+Bump version to 20.1.1
+
 #### Soroban Rust SDK
+
+Update soroban-env-\*
+Bump version to 20.3.2
+Update extend_ttl docs
+Bug 1076 conversion error flattening
+
+#### Soroban RPC
+
+Migrate Soroban Tools to Soroban RPC
+Use soroban-tools Crates
+Pull in Recent Soroban RPC changes from soroban-tools
+Mirror Last Remaining PRs from soroban-tools Repo
+Add Workflow to Publish soroban-rpc Crate
+added user agent config on ha archive pool
+Update getTxn rpc with events data
+Remove publish-dry-run Workflow
+Use external soroban-simulation library for preflight computations
+Store and serve the event transaction ID
+Reduce event memory footprint
+Add diagnostic events to sendTransaction response
+Remove panics from internal codebase
+
+#### Soroban CLI
+
+feat: soroban init command
+Bump dependencies for pubnet release
+Upgrade Ubuntu to 22.04 from 20.04
+Bump Go, Rust and Core dependencies
+feat/cli: Move config commands to top level
+bindings-ts: update to latest SDK & TypeScript, add CI test
+TypeScript bindings have been updated to use the latest stellar-sdk
+Support multi-auth workflows in typescript bindings
+Replace cli xdr command with stellar-xdr cli
+Update typescript bindings for latest versions
+Warn about RC versions only when using pubnet
 
 ## Stable v20.1.0 (January 11, 2024)
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -18,36 +18,31 @@ Release candidates are software releases that are also released to the [Testnet]
 
 ### Software
 
-| Software                     | Version                                                                                                                            |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| XDR                          | [b96148cd4acc372cc9af17b909ffe4b12c43ecb6](https://github.com/stellar/stellar-xdr/commit/b96148cd4acc372cc9af17b909ffe4b12c43ecb6) |
-| Soroban Environment          | `v20.2.2`                                                                                                                          |
-| Soroban Interface Version    | `0`                                                                                                                                |
-| Stellar Core                 | `v20.2.0`                                                                                                                          |
-| Soroban Rust SDK             | `v20.3.0`                                                                                                                          |
-| Soroban CLI                  | `v20.3.0`                                                                                                                          |
-| Soroban RPC                  | `v20.3.1`                                                                                                                          |
-| Stellar Horizon              | `v2.27.0`                                                                                                                          |
-| Stellar Friendbot            | `TBD`                                                                                                                              |
-| Stellar Quickstart           | `docker.io/stellar/quickstart:latest@sha256:8d6f6520ad3842042bfe4e271f8b2324ec2f128564487abedd3876cea83af4f1`                      |
-| Stellar JS Stellar Base      | [`v11.0.0`](https://github.com/stellar/js-stellar-base/releases/tag/v11.0.0)                                                       |
-| Stellar JS Stellar SDK       | [`v11.2.2`](https://github.com/stellar/js-stellar-sdk/releases/tag/v11.2.2)                                                        |
-| Freighter                    | `5.16.0`                                                                                                                           |
-| Laboratory                   | `v4.1.0`                                                                                                                           |
-| Soroban React Payment dapp   | `v3.0.0`                                                                                                                           |
-| Soroban Mint Token dapp      | `v3.0.0`                                                                                                                           |
-| Soroban Swap Token dapp      | `TBD`                                                                                                                              |
-| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022`                                                                                           |
-| Testnet Network Passphrase   | `Test SDF Network ; September 2015`                                                                                                |
+| Software                     | Version                                                                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| XDR                          | [8b9d623ef40423a8462442b86997155f2c04d3a1](https://github.com/stellar/rs-stellar-xdr/commit/8b9d623ef40423a8462442b86997155f2c04d3a1) |
+| Soroban Environment          | `v20.2.2`                                                                                                                             |
+| Soroban Interface Version    | `0`                                                                                                                                   |
+| Stellar Core                 | `v20.2.0`                                                                                                                             |
+| Soroban Rust SDK             | `v20.3.2`                                                                                                                             |
+| Soroban CLI                  | `v20.3.0`                                                                                                                             |
+| Soroban RPC                  | `v20.3.1`                                                                                                                             |
+| Stellar Horizon              | `v2.28.3`                                                                                                                             |
+| Stellar Friendbot            | `TBD`                                                                                                                                 |
+| Stellar Quickstart           | `docker.io/stellar/quickstart:latest@sha256:8d6f6520ad3842042bfe4e271f8b2324ec2f128564487abedd3876cea83af4f1`                         |
+| Stellar JS Stellar Base      | [`v11.0.0`](https://github.com/stellar/js-stellar-base/releases/tag/v11.0.0)                                                          |
+| Stellar JS Stellar SDK       | [`v11.2.2`](https://github.com/stellar/js-stellar-sdk/releases/tag/v11.2.2)                                                           |
+| Freighter                    | `5.16.0`                                                                                                                              |
+| Laboratory                   | `v4.1.0`                                                                                                                              |
+| Soroban React Payment dapp   | `v3.0.0`                                                                                                                              |
+| Soroban Mint Token dapp      | `v3.0.0`                                                                                                                              |
+| Soroban Swap Token dapp      | `TBD`                                                                                                                                 |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022`                                                                                              |
+| Testnet Network Passphrase   | `Test SDF Network ; September 2015`                                                                                                   |
 
 ### Changelog
 
 #### Soroban Rust SDK
-
-- Fix bug with Timepoint/Duration as parameters/returns
-- Add storage update fns
-- Export functions for creating Timepoint/Duration
-- Allow `&Env` in contract fns
 
 ## Stable v20.1.0 (January 11, 2024)
 


### PR DESCRIPTION
This PR adds a `Stable v20.2.0` section to the releases page, referencing the latest release version for all listed items.