### PR TITLE
Remove version from soroban-cli install instruction

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -73,7 +73,7 @@ The [Soroban CLI](http://github.com/stellar/soroban-cli) can execute Soroban con
 Install the [latest released version](https://github.com/stellar/soroban-cli/releases) of Soroban CLI using `cargo install`.
 
 ```bash
-cargo install --locked --version 20.3.1 soroban-cli
+cargo install --locked soroban-cli
 ```
 
 :::info


### PR DESCRIPTION
### What
Remove version from soroban-cli install instruction.

### Why
Most of the time people should install the latest version.

We're failing to keep this updated which is harming developer experience.

Now that we're releasing stable versions, it's very unlikely someone would have a problem installing a newer soroban-cli.

There will be a window for new protocol releases where the cli could support features that work on a local or test network, but not on the pubnet network, but I think we'd be introducing them in a way that the CLI would work for both protocol versions.

We used to need to specify a version because we were releasing pre-releases that can't be selected automatically. That's no longer the case.