### PR TITLE
[Stellar Merge] Add redirects and external URLs for a new "Reference" section

### DIFF
--- a/docs/reference/networks.mdx
+++ b/docs/reference/networks.mdx
@@ -2,7 +2,17 @@
 sidebar_position: 30
 title: Networks
 description: The shared Soroban test networks.
+sidebar_custom_props:
+  migration:
+    href: https://developers.stellar.org/docs/reference/networks
+    label: Networks
 ---
+
+:::danger These are not the droids you're looking for
+
+This page has been migrated to the Stellar Developers documentation. Please [click here](https://developers.stellar.org/docs/reference/networks) for the most up-to-date information
+
+:::
 
 Read more about the different networks in the [Networks section](https://developers.stellar.org/docs/fundamentals-and-concepts/networks) in the Stellar docs.
 

--- a/docs/reference/resource-limits-fees.mdx
+++ b/docs/reference/resource-limits-fees.mdx
@@ -1,7 +1,17 @@
 ---
 sidebar_position: 35
 title: Resource Limits & Fees
+sidebar_custom_props:
+  migration:
+    href: https://developers.stellar.org/docs/reference/resource-limits-fees
+    label: Resource Limits & Fees
 ---
+
+:::danger These are not the droids you're looking for
+
+This page has been migrated to the Stellar Developers documentation. Please [click here](https://developers.stellar.org/docs/reference/resource-limits-fees) for the most up-to-date information
+
+:::
 
 ## Resource Limits
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -2,7 +2,17 @@
 sidebar_position: 90
 title: Releases
 description: Soroban software releases and changelogs.
+sidebar_custom_props:
+  migration:
+    href: https://developers.stellar.org/docs/reference/software-versions
+    label: Releases
 ---
+
+:::danger These are not the droids you're looking for
+
+This page has been migrated to the Stellar Developers documentation. Please [click here](https://developers.stellar.org/docs/reference/software-versions) for the most up-to-date information
+
+:::
 
 We're releasing early versions of Soroban because we believe it's important to share the development process, and we want Stellar ecosystem developers and smart contract developers from other ecosystems to have a chance to experiment and provide feedback.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,15 +54,7 @@ const config = {
       "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        blog: {
-          path: 'meeting-notes',
-          blogTitle: 'Meeting Notes',
-          blogDescription: 'Notes and recordings from the Soroban protocol & developers meetings',
-          blogSidebarTitle: 'All meetings',
-          blogSidebarCount: 'ALL',
-          postsPerPage: 'ALL',
-          routeBasePath: 'meetings',
-        },
+        blog: false,
         docs: {
           showLastUpdateTime: true,
           showLastUpdateAuthor: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,7 +125,7 @@ const config = {
             position: 'left'
           },
           {
-            to: '/meetings',
+            to: 'https://developers.stellar.org/meetings',
             label: 'Meetings',
             position: 'right',
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,7 +125,7 @@ const config = {
             position: 'left'
           },
           {
-            to: 'https://developers.stellar.org/meetings',
+            href: 'https://developers.stellar.org/meetings',
             label: 'Meetings',
             position: 'right',
           },

--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -1,5 +1,5 @@
 rewrite "^/docs/category/examples$" "/docs/tutorials" permanent;
-rewrite "^/docs/getting-started/run-rpc$" "/docs/reference/rpc" permanent;
+rewrite "^/docs/getting-started/run-rpc$" "https://developers.stellar.org/network/soroban-rpc/admin-guide" permanent;
 rewrite "^/docs/category/tutorials$" "/docs/tutorials" permanent;
 rewrite "^/docs/tutorials/deploy-to-futurenet$" "/docs/getting-started/deploy-to-testnet" permanent;
 rewrite "^/fundamentals-and-concepts/faq$" "/docs/faq" permanent;
@@ -23,18 +23,18 @@ rewrite "^/sorobanathon" "/" permanent;
 rewrite "^/docs/reference/interfaces/token-interface" "/docs/tokens/token-interface" permanent;
 rewrite "^/docs/category/getting-started$" "/docs/getting-started/setup" permanent;
 rewrite "^/docs/tutorials/stellar-asset-contract" "/docs/tokens/stellar-asset-contract" permanent;
-rewrite "^/docs/category/migrating-from-evm$" "/docs/migrate/evm/introduction-to-solidity-and-rust" permanent;
-rewrite "^/docs/fundamentals-and-concepts/migrating-from-evm(/.*)$" "/docs/migrate/evm$1" permanent;
-rewrite "^/docs/reference/releases$" "/docs/releases" permanent;
+rewrite "^/docs/category/migrating-from-evm$" "https://developers.stellar.org/docs/learn/migrate/evm" permanent;
+rewrite "^/docs/fundamentals-and-concepts/migrating-from-evm(/.*)$" "https://developers.stellar.org/docs/learn/migrate/evm$1" permanent;
+rewrite "^/docs/reference/releases$" "https://developers.stellar.org/docs/reference/software-versions" permanent;
 rewrite "^/docs/fundamentals-and-concepts/faq$" "/docs/faq" permanent;
-rewrite "^/docs/reference/testnet$" "/docs/reference/networks" permanent;
+rewrite "^/docs/reference/testnet$" "https://developers.stellar.org/docs/reference/networks" permanent;
 rewrite "^/docs/fundamentals-and-concepts/(built-in-types|custom-types|fully-typed-contracts)$" "https://developers.stellar.org/docs/learn/smart-contract-internals/types/$1" permanent;
 rewrite "^/docs/fundamentals-and-concepts/invoking-contracts-with-transactions$" "https://developers.stellar.org/docs/learn/smart-contract-internals/contract-interactions/stellar-transaction" permanent;
 rewrite "^/docs/soroban-internals/contract-interactions/stellar-transactions$" "https://developers.stellar.org/docs/learn/smart-contract-internals/contract-interactions/stellar-transaction" permanent;
 rewrite "^/docs/fundamentals-and-concepts/interacting-with-contracts$" "https://developers.stellar.org/docs/learn/smart-contract-internals/contract-interactions" permanent;
 rewrite "^/docs/(basic|advanced)-tutorials(/.*)$" "/docs/tutorials$2" permanent;
 rewrite "^/docs/fundamentals-and-concepts(/.*)$" "https://developers.stellar.org/docs/learn/smart-contract-internals$1" permanent;
-rewrite "^/docs/notes" "/meetings" permanent;
+rewrite "^/docs/notes" "https://developers.stellar.org/meetings" permanent;
 ##### BEGIN merge redirects
 # developer tools and SDK
 rewrite "^/docs/developer-tools" "https://developers.stellar.org/docs/tools/developer-tools" permanent;
@@ -57,6 +57,7 @@ rewrite "^/docs/reference/rpc-list$" "https://developers.stellar.org/network/sor
 rewrite "^/docs/reference/networks$" "https://developers.stellar.org/docs/reference/networks" permanent;
 rewrite "^/docs/reference/resource-limits-fees$" "https://developers.stellar.org/docs/reference/resource-limits-fees" permanent;
 rewrite "^/docs/reference/releases(.*)$" "https://developers.stellar.org/docs/reference/software-versions$1" permanent;
+rewrite "^/meetings(.*)$" "https://developers.stellar.org/meetings$1" permanent;
 # learn
 rewrite "^/docs/category/soroban-internals$" "https://developers.stellar.org/docs/learn/smart-contract-internals" permanent;
 rewrite "^/docs/soroban-internals/contract-interactions$" "https://developers.stellar.org/docs/learn/smart-contract-internals/contract-interactions/overview" permanent;

--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -53,3 +53,6 @@ rewrite "^/api/incomplete-methods$" "https://developers.stellar.org/network/soro
 rewrite "^/api(.*)" "https://developers.stellar.org/network/soroban-rpc$1" permanent;
 rewrite "^/docs/reference/rpc$" "https://developers.stellar.org/network/soroban-rpc/admin-guide" permanent;
 rewrite "^/docs/reference/rpc-list$" "https://developers.stellar.org/network/soroban-rpc/rpc-providers" permanent;
+rewrite "^/docs/reference/networks$" "https://developers.stellar.org/docs/reference/networks" permanent;
+rewrite "^/docs/reference/resource-limits-fees$" "https://developers.stellar.org/docs/reference/resource-limits-fees" permanent;
+rewrite "^/docs/reference/releases(.*)$" "https://developers.stellar.org/docs/reference/software-versions$1" permanent;

--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -51,6 +51,7 @@ rewrite "^/docs/reference/data-providers" "https://developers.stellar.org/docs/t
 rewrite "^/methods/getTransaction$" "https://developers.stellar.org/network/soroban-rpc/methods/getTransaction" permanent;
 rewrite "^/api/incomplete-methods$" "https://developers.stellar.org/network/soroban-rpc/methods" permanent;
 rewrite "^/api(.*)" "https://developers.stellar.org/network/soroban-rpc$1" permanent;
+# reference
 rewrite "^/docs/reference/rpc$" "https://developers.stellar.org/network/soroban-rpc/admin-guide" permanent;
 rewrite "^/docs/reference/rpc-list$" "https://developers.stellar.org/network/soroban-rpc/rpc-providers" permanent;
 rewrite "^/docs/reference/networks$" "https://developers.stellar.org/docs/reference/networks" permanent;

--- a/sidebars.js
+++ b/sidebars.js
@@ -7,7 +7,7 @@ module.exports = {
     {
       type: 'link',
       label: 'Meeting Notes',
-      href: '/meetings',
+      href: 'https://developers.stellar.org/meetings',
     }
   ]
 };


### PR DESCRIPTION
The following will be moving over to the `stellar-docs` repo

- Meeting notes
- `docs/reference/resource-limits-fees.mdx`
- `docs/reference/networks.mdx`
- `docs/reference/{releases => software-versions}.mdx`

Refs: #740, stellar/stellar-docs#362